### PR TITLE
7 kgo update script

### DIFF
--- a/kgo_updates/kgo_update/kgo_update.py
+++ b/kgo_updates/kgo_update/kgo_update.py
@@ -338,7 +338,7 @@ def get_variables_file_path(suite_dir, site, platform, variables_extension):
             return variables_path
 
     # Search for a variables. file if a platform one doesn't exist, eg. VM site
-    vars_file = "variables.rc"
+    vars_file = f"variables{variables_extension}"
     variables_path = os.path.join(site_path, vars_file)
     print("INFO: Looking for a kgo variables file at "
             + variables_path)

--- a/kgo_updates/kgo_update/kgo_update.py
+++ b/kgo_updates/kgo_update/kgo_update.py
@@ -312,36 +312,39 @@ def get_site():
         site = stdout.decode('utf-8').split("=")[1].strip()
         print("Found site via rose-config: {0}\n".format(site))
     else:
-        site = None
-        print("No site found via 'rose config' ...")
+        sys.exit(
+            "No site was detected via rose config - this setting is required"
+        )
     return site
 
 
 def get_variables_file_path(suite_dir, site, platform, variables_extension):
     """
     Find the path to the file containing kgo version info
-    Is one of variables.rc, variables.cylc or kgo_variables.cylc for lfric_apps
+    Uses the variables_extension to search for both .cylc and .rc files
+    If the platform is set, it will search for variables_<platform>.extension
+    otherwise just variables.extension
     """
 
-    if site is not None:
-        vars_file = "variables.rc"
-        if platform is not None:
-            vars_file = f"variables_{platform}{variables_extension}"
-        variables_path = os.path.join(
-            suite_dir,
-            "site",
-            site,
-            vars_file
-        )
+    site_path = os.path.join(suite_dir, "site", site)
+
+    # Search for a variables_<platform>. file
+    if platform is not None:
+        vars_file = f"variables_{platform}{variables_extension}"
+        variables_path = os.path.join(site_path, vars_file)
         print("INFO: Looking for a kgo variables file at "
                 + variables_path)
         if os.path.exists(variables_path):
             return variables_path
-        variables_path = os.path.join(suite_dir,
-                                      f"variables{variables_extension}")
-        print(f"INFO: Trying to find a variables file at {variables_path}")
-        if os.path.exists(variables_path):
-            return variables_path
+
+    # Search for a variables. file if a platform one doesn't exist, eg. VM site
+    vars_file = "variables.rc"
+    variables_path = os.path.join(site_path, vars_file)
+    print("INFO: Looking for a kgo variables file at "
+            + variables_path)
+    if os.path.exists(variables_path):
+        return variables_path
+
     sys.exit("ERROR: Couldn't find a kgo variables file")
 
 

--- a/kgo_updates/kgo_update/kgo_update.py
+++ b/kgo_updates/kgo_update/kgo_update.py
@@ -323,8 +323,10 @@ def get_variables_file_path(suite_dir, site, platform, variables_extension):
     Is one of variables.rc, variables.cylc or kgo_variables.cylc for lfric_apps
     """
 
-    if site is not None and platform is not None:
-        vars_file = f"variables_{platform}{variables_extension}"
+    if site is not None:
+        vars_file = "variables.rc"
+        if platform is not None:
+            vars_file = f"variables_{platform}{variables_extension}"
         variables_path = os.path.join(
             suite_dir,
             "site",

--- a/kgo_updates/kgo_update/kgo_update.py
+++ b/kgo_updates/kgo_update/kgo_update.py
@@ -5,7 +5,7 @@
 # which you should have received as part of this distribution.
 # *****************************COPYRIGHT*******************************
 """
-This script will parse the rose-ana-comparisons.db produces by a valid
+This script will parse the rose-ana-comparisons.db produced by a valid
 rose-stem suite, writing and executing a sub-script which performs a
 KGO update (creating new KGO folders and installing the required files)
 
@@ -23,7 +23,7 @@ Optional Arguments:
                      found in.
 => --non-interactive Run in non-interactive mode. The suite will not ask any
                      questions. This is not a recommended option
-=> --new-release     Only for use by the UM Systems Team when releasing a new
+=> --new-release     Only for use by the Systems Team when releasing a new
                      version of the UM
 => -P Specify the platform this is being run on. Currently only relevant if the
       site is meto - if so then it will be automatically populated if not given

--- a/kgo_updates/kgo_update/kgo_update.py
+++ b/kgo_updates/kgo_update/kgo_update.py
@@ -475,7 +475,7 @@ def main():
                         "running on. Defaults as ''. If the site is meto then"
                         "the platform will be autopopulated.")
 
-    parser.add_argument('-E', "--extension",
+    parser.add_argument('-E', "--extension", default=".rc",
                         help="The extension of the variables file, either .rc "
                         "or .cylc")
 

--- a/kgo_updates/kgo_update/kgo_update.py
+++ b/kgo_updates/kgo_update/kgo_update.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python
+# *****************************COPYRIGHT*******************************
+# (C) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT.txt
+# which you should have received as part of this distribution.
+# *****************************COPYRIGHT*******************************
+"""
+This script will parse the rose-ana-comparisons.db produces by a valid
+rose-stem suite, writing and executing a sub-script which performs a
+KGO update (creating new KGO folders and installing the required files)
+
+This script will no longer ask questions of the user and instead expects to be
+passed arguments as command line arguments. The suite expects as minimum:
+    python3 kgo_update.py -S <suite_name> -U <suite_user> -N <new_kgo_dir>
+
+Required Command Line Arguments:
+=> -S The name of the suite with the new kgo
+=> -U The username of the owner of the above suite
+
+Optional Arguments:
+=> --new-kgo-dir -N  Give the name of the new kgo dir. If not specified then the
+                     suite will install kgo to the directory kgois currently
+                     found in.
+=> --non-interactive Run in non-interactive mode. The suite will not ask any
+                     questions. This is not a recommended option
+=> --new-release     Only for use by the UM Systems Team when releasing a new
+                     version of the UM
+=> -P Specify the platform this is being run on. Currently only relevant if the
+      site is meto - if so then it will be automatically populated if not given
+
+
+"""
+import os
+import re
+import sys
+import sqlite3
+import argparse
+import subprocess
+from collections import defaultdict
+
+if sys.version_info.major == 2:
+    sys.exit("kgo_update.py can no longer be run using python2")
+
+# Global criteria for updating - any statuses matched by this list will
+# be treated as "failed" for the purposes of updating.  When running a
+# "new version" update this list will be updated to include the "OK"
+# status, causing all tested files to be updated.
+UPDATE_CRITERIA = ["WARN", "FAIL"]
+
+
+def banner(message):
+    '''Print a simple banner message'''
+    return "{0}\n* {1} *\n{0}".format("%"*(len(message)+4), message)
+
+
+def confirm(message, skip=False):
+    "Prompt the user for a response"
+    if skip:
+        print("Non-interactive mode, skipping question: ")
+        print(message)
+        return True
+    while True:
+        check = input(message)
+        if check in ["Y", "y", "yes"]:
+            print("")
+            return True
+        elif check in ["N", "n", "no"]:
+            print("")
+            return False
+
+
+def write_update_script(kgo_dirs, new_dirname, script):
+    "Write the update script to a file"
+    total_filesize = 0
+
+    # Start the script with a header
+    script.write("#!/bin/bash\n")
+    script.write("set -eu\n")
+
+    for kgo_dir in sorted(kgo_dirs.keys()):
+        update_dict = kgo_dirs[kgo_dir]
+        # Construct the new KGO directory name
+        if new_dirname == "install_in_place":
+            # In non-interactive mode, the user may choose to install the
+            # files to the existing KGO location instead of a new directory,
+            # in which case we just use the existing directory here
+            new_kgo_dir = kgo_dir
+        else:
+            # Otherwise construct it by replacing the existing name with
+            # the new one
+            new_kgo_dir = os.path.join(os.path.dirname(kgo_dir), new_dirname)
+
+        # Write a sub-header for this KGO directory to help visually split
+        # up the file (for when the user checks it by eye)
+        script.write("#"*(len(new_kgo_dir)+4)+"\n")
+        script.write("# {0} #\n".format(new_kgo_dir))
+        script.write("#"*(len(new_kgo_dir)+4)+"\n")
+        script.write(f"echo 'Installing {new_kgo_dir}'\n\n")
+
+        # Build up several different text sections in the upcoming loop
+        # (so that they can be printed in groups)
+        keep_description = ["# Files to be kept from previous KGO: "]
+        keep_commands = []
+        copy_description = ["# Files to be copied from suite: "]
+        copy_commands = []
+        mkdir_commands = []
+        mkdir_commands.append("echo 'mkdir -p {0}'".format(new_kgo_dir))
+        mkdir_commands.append("mkdir -p {0}".format(new_kgo_dir))
+
+        kgo_files = sorted(update_dict.keys())
+        for kgo_file in kgo_files:
+            source = update_dict[kgo_file]
+
+            # Ensure any subdirectories are created as needed
+            subdir = os.path.dirname(kgo_file)
+            if subdir != "":
+                full_subdir = os.path.join(new_kgo_dir, subdir)
+                mkdir_commands.append("echo 'mkdir -p {0}'".format(full_subdir))
+                mkdir_commands.append("mkdir -p {0}".format(full_subdir))
+
+            if source is None:
+                # Files being kept should be sym-linked back to the previous
+                # revision, to save space
+                if "OK" in UPDATE_CRITERIA:
+                    # However, if this is a version upgrade any tasks
+                    # without a source here must have been retired from
+                    # the tests
+                    continue
+                keep_description.append(
+                    "#    * {0}".format(kgo_file))
+
+                # Construct the paths
+                old_file = os.path.join(kgo_dir, kgo_file)
+                new_file = os.path.join(new_kgo_dir, kgo_file)
+
+                keep_commands.append(
+                    "echo 'ln -s {0} {1}'".format(
+                        os.path.relpath(old_file,
+                                        os.path.dirname(new_file)),
+                        new_file))
+                keep_commands.append(
+                    "ln -s {0} {1}".format(
+                        os.path.relpath(old_file,
+                                        os.path.dirname(new_file)),
+                        new_file))
+            else:
+                # Files from the suite should be copied from the suite
+                copy_description.append(
+                    "#    * {0}".format(kgo_file))
+                new_file = os.path.join(new_kgo_dir, kgo_file)
+                copy_commands.append(
+                    "echo 'cp {0} {1}'".format(source, new_file))
+                copy_commands.append(
+                    "cp {0} {1}".format(source, new_file))
+                # In this case more disk-space is needed, so update
+                # the running total for reporting later
+                total_filesize += os.path.getsize(source)
+
+        # Can now write this tasks output to the file:
+        if len(keep_description) > 1:
+            script.write("\n".join(keep_description) + "\n\n")
+        if len(copy_description) > 1:
+            script.write("\n".join(copy_description) + "\n\n")
+        script.write("# Creating new KGO directories:\n")
+        script.write("\n".join(mkdir_commands) + "\n\n")
+        if len(keep_commands) > 0:
+            script.write("# Linking back to unchanged KGO files:\n")
+            script.write("\n".join(keep_commands) + "\n\n")
+        if len(copy_commands) > 0:
+            script.write("# Copying new KGO files from suite:\n")
+            script.write("\n".join(copy_commands) + "\n\n")
+
+    return total_filesize
+
+
+def report_space_required(total_filesize, skip=False):
+    "Let the user know how much space they need for the update"
+    # Report the amount of disk space required
+    units = ["TB", "GB", "MB", "kB", "B"]
+    while total_filesize > 1024.0 and len(units) > 1:
+        total_filesize = total_filesize / 1024.0
+        units.pop()
+    unit = units[-1]
+
+    print(banner("Update will require: {0:.2f} {1} of disk space"
+                 .format(total_filesize, unit)))
+    if not confirm("Please confirm this much space is available (y/n)? ",
+                   skip=skip):
+        sys.exit("Aborting...")
+
+
+def add_untested_kgo_files(kgo_dirs):
+    "Add any files present in the KGO directory but not tested by the suite"
+    for kgo_dir, update_dict in kgo_dirs.items():
+        for path, _, filenames in os.walk(kgo_dir):
+            for filename in filenames:
+                kgo_file = (
+                    os.path.relpath(os.path.join(path, filename), kgo_dir))
+                if kgo_file not in update_dict:
+                    kgo_dirs[kgo_dir][kgo_file] = None
+    return kgo_dirs
+
+
+def group_comparisons_by_dir(comparisons, skip=False):
+    """
+    Group the key details from the list of comparisons by the KGO
+    directory they are referencing.
+
+    """
+    kgo_dirs = defaultdict(dict)
+    for _, kgo_file, suite_file, status, _ in comparisons:
+
+        # If the kgo_file isn't set, move on (in some cases the test is not
+        # comparing two files at all
+        if kgo_file is None:
+            continue
+
+        # If it looks like this KGO file never existed at all, let the user
+        # decide what they want to happen
+        if not os.path.exists(kgo_file) and status.strip() in UPDATE_CRITERIA:
+            if not confirm("KGO file {0} doesn't appear to exist, should we "
+                           "install it from the suite (y/n)? "
+                           .format(kgo_file), skip=skip):
+                # Note this is negated - i.e. if the user doesn't want to
+                # include this new file, we skip it and move on
+                continue
+
+        # Extract the base KGO directory by moving backwards through the path
+        # until a directory that matches the KGO directory naming style
+        basedir = os.path.dirname(kgo_file)
+        while (basedir != "/" and not
+               re.match(r".*((vn|\d+\.)\d+\.\d+(_t\d+|))$", basedir)):
+            basedir = os.path.dirname(basedir)
+
+        # If the above goes wrong it will eventually hit root; if this happens
+        # we cannot continue as something is seriously not right
+        if basedir == "/":
+            msg = ("Problem locating KGO directory - "
+                   "is this actually a KGO file?\n  {0}")
+            sys.exit(msg.format(kgo_file))
+
+        # Otherwise add the result to the list - for each entry we store the
+        # relative path to the KGO file and the full path to the file in the
+        # suite which should be used to update it (if it needs updating)
+        if status.strip() in UPDATE_CRITERIA:
+
+            # Here we could check if this update has already been lodged,
+            # and if it has perhaps we can do some additional checking
+            # (for instance, are the changes in answers the same?)
+            relative_kgo_path = os.path.relpath(kgo_file, basedir)
+            if (relative_kgo_path in kgo_dirs[basedir] and
+                    kgo_dirs[basedir][relative_kgo_path] != suite_file):
+                # Or not... it isn't clear what could be checked here
+                continue
+
+            kgo_dirs[basedir][relative_kgo_path] = suite_file
+
+    return kgo_dirs
+
+
+def get_all_kgo_comparisons(conn):
+    "Retrieve all comparisons related to KGO tasks"
+    res = conn.execute("SELECT comp_task, kgo_file, suite_file, "
+                       "status, comparison FROM comparisons")
+    return res.fetchall()
+
+
+def check_for_incomplete_tasks(conn, skip=False):
+    "Check the database to see if all tasks are complete"
+    res = conn.execute("SELECT task_name FROM tasks WHERE completed==?", (1,))
+    failed_tasks = res.fetchall()
+    if len(failed_tasks) > 0:
+        print("WARNING - Some comparisons are either still running or "
+              "failed to complete properly:")
+        for task in failed_tasks:
+            print("  * "+task[0])
+        print("Please investigate this manually - no KGO updates will be "
+              "made for any of the tasks listed above")
+        if not confirm("Continue anyway (y/n)? ", skip=skip):
+            sys.exit()
+
+
+def connect_to_kgo_database(suite_dir):
+    "Make a connection to the comparisons database in a given suite"
+    db_filename = os.path.join(suite_dir, "log", "rose-ana-comparisons.db")
+    if not os.path.exists(db_filename):
+        msg = "ERROR: Suite comparison database not found at {0}"
+        sys.exit(msg.format(db_filename))
+    return sqlite3.connect(db_filename)
+
+
+def get_suite_dir(user, suite_name):
+    "Returns the path to the given suite directory of a given user"
+    suite_dir = "~{0}/cylc-run/{1}".format(user, suite_name)
+    expansion = os.path.expanduser(suite_dir)
+    if expansion == suite_dir or not os.path.exists(expansion):
+        msg = "ERROR: Unable to find suite ({0})"
+        sys.exit(msg.format(expansion))
+    else:
+        return expansion
+
+
+def get_site():
+    """
+    Function to return the site this is being run at using rose config
+    """
+    command = ["rose", "config", "rose-stem", "automatic-options"]
+    cmd = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = cmd.communicate()
+    retcode = cmd.returncode
+    if retcode == 0:
+        site = stdout.decode('utf-8').split("=")[1].strip()
+        print("Found site via rose-config: {0}\n".format(site))
+    else:
+        site = None
+        print("No site found via 'rose config' ...")
+    return site
+
+
+def update_variables_rc(suite_dir, kgo_dirs, new_kgo_dir, site, platform,
+                                                                 skip=False):
+    """
+    Create an updated copy of the variables.rc with the KGO variables for
+    any changed jobs updated
+    """
+
+    # Attempt to get a copy of the variables.rc
+    if site is not None:
+        print("INFO: Look in rose-stem/site/{0} directory for variables.rc "
+               "file".format(site))
+        vars_file = "variables.rc"
+        if platform is not None:
+            vars_file = f"variables_{platform}.rc"
+        variables_rc = os.path.join(suite_dir, "site", site, vars_file)
+        if not os.path.exists(variables_rc):
+            print("INFO: variables.rc not found at {0}, trying base of "
+                   "rose-stem directory".format(variables_rc))
+            variables_rc = os.path.join(suite_dir, "variables.rc")
+    else:
+        print("INFO: No SITE found, so looking in base of rose-stem "
+               "directory for variables.rc file.")
+        variables_rc = os.path.join(suite_dir, "variables.rc")
+
+    if not os.path.exists(variables_rc):
+        sys.exit(f"ERROR: {variables_rc} not found.")
+
+    # Create a file to hold the new variables.rc
+    variables_rc_new = os.path.expanduser(
+        "~/variables.rc_{0}".format(new_kgo_dir))
+    if os.path.exists(variables_rc_new):
+        print("WARNING: New variables.rc file for this update already exists "
+              "at {0} and will be overwritten".format(variables_rc_new))
+        if not confirm("Okay to overwrite variables.rc file (y/n)? ",
+                       skip=skip):
+            sys.exit("Aborting...")
+
+    # Get the KGO variable names that need updating
+    kgo_vars = []
+    for kgo_dir in kgo_dirs.keys():
+        kgo_vars.append(
+            os.path.basename(
+                os.path.dirname(kgo_dir)).upper())
+
+    # Get the suffix of the new directory
+    if "_" not in new_kgo_dir:
+        return
+    ticket_suffix = new_kgo_dir.split("_")[1]
+
+    # Rewrite the variables.rc
+    with open(variables_rc, "r") as vrc_old:
+        with open(variables_rc_new, "w") as vrc_new:
+            for line in vrc_old.readlines():
+                # Find lines with KGO variables and update them if they are
+                # named in the database
+                pattern = re.search(r'\s*"(\S+)"\s*:\s*BASE', line)
+                if pattern and pattern.group(1).upper() in kgo_vars:
+                    vrc_new.write(re.sub(
+                        r':\s*BASE.*',
+                        r': BASE~"_{}",'.format(ticket_suffix),
+                        line))
+                else:
+                    # Otherwise just write the line unaltered
+                    vrc_new.write(line)
+
+
+def main():
+    "Toplevel script function - process arguments and run update"
+
+    print(banner("Starting KGO Update"))
+
+    # Create a quick version of the regular raw description formatter which
+    # adds spaces between the option help text
+    class BlankLinesHelpFormatter(argparse.HelpFormatter):
+        "Formatter which adds blank lines between options"
+        def _split_lines(self, text, width):
+            return super(
+                BlankLinesHelpFormatter, self)._split_lines(text, width) + ['']
+
+    parser = argparse.ArgumentParser(
+        usage="%(prog)s [--new-release]",
+        description="""
+        KGO Update - A semi-interactive tool for updating UM KGO.
+
+        This script will scan the rose_ana comparisons database to
+        prepare and run a shell script to update the KGO files for
+        any failed tasks (or all tasks if the --new-release option
+        is used)
+        """,
+        formatter_class=BlankLinesHelpFormatter,
+        )
+
+    parser.add_argument('--new-release',
+                        help="if set, indicates that the task being "
+                        "performed is installing a full set of new KGO "
+                        "for a major model release instead of simply "
+                        "updating failed KGO tasks.",
+                        action="store_true",
+                        )
+
+    parser.add_argument('--non-interactive',
+                        help="if set, no questions will be asked and "
+                        "the script will proceed without any checking "
+                        "or warnings.  Use with caution.",
+                        action="store_true",
+                        )
+
+    parser.add_argument('-S', "--suite-name",
+                        help="specifies the (cylc-run dir) name of "
+                        "the suite containing the KGO database; for "
+                        "use with non-interactive mode.  If not given "
+                        "non-interactive mode will try to take "
+                        "this from the environment ($CYLC_SUITE_NAME)."
+                        )
+
+    parser.add_argument('-U', "--suite-user",
+                        help="specifies the (cylc-run dir) username "
+                        "where the KGO database suite can be found; for "
+                        "use with non-interactive mode.  If not given "
+                        "non-interactive mode will try to take "
+                        "this from the environment ($USER)."
+                        )
+
+    parser.add_argument('-N', "--new-kgo-dir",
+                        help="specifies the name of the new KGO "
+                        "subdirectory; for use with non-interactive "
+                        "mode. If not given the KGO files will be "
+                        "installed directly to the location currently "
+                        "specified by the suite."
+                        )
+
+    parser.add_argument('-P', "--platform",
+                        help="specifies the platform this script is "
+                        "running on. Defaults as ''. If the site is meto then"
+                        "the platform will be autopopulated.")
+
+    args = parser.parse_args()
+
+    if args.new_release:
+        # If releasing a new version, extend the criteria for performing
+        # a KGO update to include tasks which completed successfully
+        UPDATE_CRITERIA.append("OK")
+
+    suite_name = args.suite_name
+    suite_user = args.suite_user
+    new_kgo_dir = args.new_kgo_dir
+    if new_kgo_dir is None:
+        new_kgo_dir = "install_in_place"
+    platform = args.platform
+
+    if suite_name is None or suite_user is None:
+        message = "'kgo_update.py' will no longer ask for your suite "\
+                    "information\n.To pass this into the script please use "\
+                    "the command line arguments.\nThese are documented at "\
+                    "the top of the file."
+        sys.exit(message)
+
+    # Prompt the user for the key options
+    if args.non_interactive:
+        confirm_skip = True
+        interactive = False
+    else:
+        confirm_skip = False
+        interactive = True
+
+    suite_dir = get_suite_dir(suite_user, suite_name)
+
+    # Get the site being run at
+    site = get_site()
+    if site == 'meto' and new_kgo_dir == "install_in_place":
+        message = "Site meto should not use the 'install_in_place' option. "\
+                    "Check --new-kgo-dir is specified on the command line." \
+                    "Do you want to continue with the update?"
+        if not confirm(message, False):
+            sys.exit()
+
+    # Populate platform if not provided and at meto
+    if platform is None and site == 'meto':
+        hostname = os.uname()[1]
+        if hostname == 'uan01':
+            platform = "ex1a"
+        elif hostname.startswith("xc"):
+            platform = "xc40"
+        else:
+            platform = "spice"
+
+    # Make a connection to the database
+    conn = connect_to_kgo_database(suite_dir)
+
+    # See if any tasks have not finished yet
+    check_for_incomplete_tasks(conn, skip=confirm_skip)
+
+    # Extract the comparisons
+    comparisons = get_all_kgo_comparisons(conn)
+
+    # Group these by KGO directory
+    kgo_dirs = group_comparisons_by_dir(comparisons, skip=confirm_skip)
+
+    # Add in any files in the previous KGO untested by the suite
+    kgo_dirs = add_untested_kgo_files(kgo_dirs)
+
+    # Create a file to hold the update script
+    script_path = os.path.expanduser("~/kgo_update_{0}.sh".format(new_kgo_dir))
+    if os.path.exists(script_path):
+        print("WARNING: Script file for this update already exists at {0} "
+              "and will be overwritten".format(script_path))
+        if not confirm("Okay to overwrite script file (y/n)? ",
+                       skip=confirm_skip):
+            sys.exit("Aborting...")
+
+    # Write the script file
+    with open(script_path, "w") as script:
+        total_filesize = write_update_script(kgo_dirs, new_kgo_dir, script)
+
+    print("Script file written to: {0}\n".format(script_path))
+
+    # Report on the required space
+    report_space_required(total_filesize, skip=confirm_skip)
+
+    # Update the variables.rc (don't do this for new releases as it's part
+    # of the release process already)
+    if not args.new_release:
+        update_variables_rc(suite_dir, kgo_dirs, new_kgo_dir, site,
+                                                platform, skip=confirm_skip)
+
+    # Open the file for viewing in user's editor
+    if interactive:
+        print(f"\n\nOpening {script_path}\nHit Return to Step through, "
+                                "q to print all\n\n")
+        with open(script_path, "r") as f:
+            l = 0
+            print_all = False
+            for line in f:
+                print(line, end='')
+                l += 1
+                if l == 10 and not print_all:
+                    l = 0
+                    key = input()
+                    if key.lower() == 'q':
+                        print_all = True
+
+        print("\n\nPlease carefully check the commands in the above file "
+                "before continuing.\nIf changes need to be made then open a "
+                "new terminal and edit the file there.")
+
+    # Final confirmation before running
+    print("WARNING: Once launched the script will make permanent changes")
+    if not confirm("Are you sure you want to continue (y/n)? ",
+                   skip=confirm_skip):
+        sys.exit("Aborting...")
+
+    print(banner("Running KGO Update commands from {0}".format(script_path)),
+            flush=True)
+
+    process = subprocess.Popen(["bash", script_path],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+    while True:
+        line = process.stdout.readline()
+        if not line and process.poll() is not None:
+            break
+        print(line.decode(), end='', flush=True)
+    retcode = process.returncode
+    if retcode != 0:
+        sys.exit(f"Script did not run successfully, update failed\n"
+                f"{process.stderr.read().decode()}\n")
+
+    # Print a final message
+    print(banner("Generated KGO Script has run successfully"))
+    if site != 'meto':
+        print("\nThe script has created a copy of the variables.rc in your "
+            "$HOME directory; you should merge this with the one in your "
+            "working copy using xxdiff to update the KGO variables")
+    else:
+        print(f"\nThe kgo update for {platform} is complete.\n\nIf this was "
+               "run from 'meto_update_kgo.sh' in the UM, the generated files "
+               "will be moved to frum on spice and the process will continue "
+               "for other platforms requested.\n\nOtherwise, eg. for "
+               "lfric_inputs, you will need to merge the generated variables "
+               "file with the one in your working copy and run the script "
+               "again on the next platform.")
+
+
+if __name__ == "__main__":
+    main()

--- a/kgo_updates/kgo_update/meto_run_kgo_script.sh
+++ b/kgo_updates/kgo_update/meto_run_kgo_script.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# *****************************COPYRIGHT*******************************
+# (C) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT.txt
+# which you should have received as part of this distribution.
+# *****************************COPYRIGHT*******************************
+
+# This script is intended to be run by frum having been called by 
+# `../meto_update_kgo.sh` . It runs the `kgo_update.py` script which it
+# assumes is in the same directory. It takes suite name, suite user, version 
+# number, ticket number and required platforms as inputs. It runs the script on
+# each platform as required and then moves the generated variables file to
+# ~frum/kgo_updated_variables/vnVV.V_tTTTT/ on linux. IF xc40 is being run it
+# rsyncs with the xcs.
+# This script is NOT intended to be run independently of '../meto_update_kgo.sh'
+
+# Set colour codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Read in command line arguments
+while getopts S:U:E:N:R:P:V: flag
+do
+    case "${flag}" in
+        S) suite_name=${OPTARG};;
+        U) suite_user=${OPTARG};;
+        E) suite_user_ex1a=${OPTARG};;
+        N) new_kgo_dir=${OPTARG};;
+        R) new_release=${OPTARG};;
+        P) platforms=${OPTARG};;
+        V) version_number=${OPTARG};;
+    esac
+done
+
+# Create command to run python script
+kgo_command="./kgo_update.py"
+if [ $new_release -eq 1 ]; then
+    kgo_command="${kgo_command} --new-release"
+fi
+kgo_command="${kgo_command} -S $suite_name -N $new_kgo_dir"
+kgo_command_spice="$kgo_command -U $suite_user -P spice"
+kgo_command_xc40="$kgo_command -U $suite_user -P xc40"
+kgo_command_ex1a="$kgo_command -U $suite_user_ex1a -P ex1a"
+
+# Make a directory to store the script and variables.rc file in
+variables_dir=~/kgo_update_files/vn$version_number/$new_kgo_dir
+mkdir -p $variables_dir
+
+# If Spice has kgo updates
+if [[ $platforms == *"spice"* ]]; then
+    printf "${GREEN}\n\nRunning KGO Update Script on SPICE.\n${NC}"
+
+    # Run the Update Script
+    $kgo_command_spice
+
+    if [[ $? -ne 0 ]]; then
+        printf "${RED}\nThe installation script has failed on spice.\n${NC}"
+    else
+        # Move the updated variables file and script into the ticket folder
+        printf "${GREEN}\n\nSuccessfully installed on Spice.\n${NC}"
+        printf "${GREEN}Moving the generated files into SPICE ${variables_dir}.${NC}\n"
+        if [ $new_release -ne 1 ]; then
+            mv ~/variables.rc_${new_kgo_dir} ${variables_dir}/spice_updated_variables.rc
+        fi
+        mv ~/kgo_update_${new_kgo_dir}.sh ${variables_dir}/spice_update_script.sh
+    fi
+fi
+
+# If xc40 has kgo updates
+if [[ $platforms == *"xc40"* ]]; then
+    printf "${GREEN}\n\nRunning KGO Update Script on xc40.\n${NC}"
+
+    # SCP the python script to the xc40
+    scp -q kgo_update.py frum@xcel00:~
+
+    # Define the commands to run on xc40
+    command=". /etc/profile ; module load scitools ; 
+             ${kgo_command_xc40}"
+
+    # SSH to the xc40 with the run command
+    ssh -Y xcel00 $command
+
+    if [[ $? -ne 0 ]]; then
+        printf "${RED}\nThe installation script has failed on xc40.\n${NC}"
+    else
+        # rsync the generated variables file and script back to frum on linux
+        # This cleans up the original files
+        printf "${GREEN}\n\nSuccessfully installed on xc40.\n${NC}"
+        printf "${GREEN}Rsyncing the generated files into SPICE ${variables_dir}.\n${NC}"
+        if [ $new_release -ne 1 ]; then
+            rsync --remove-source-files -avz \
+                frum@xcel00:~/variables.rc_${new_kgo_dir} \
+                ${variables_dir}/xc40_updated_variables.rc
+        fi
+        rsync --remove-source-files -avz \
+                frum@xcel00:~/kgo_update_${new_kgo_dir}.sh \
+                ${variables_dir}/xc40_update_script.sh
+    fi
+
+    # Clean up kgo_update.py on xc40
+    ssh -Yq xcel00 "rm kgo_update.py"
+fi
+
+# If ex1a has kgo updates
+if [[ $platforms == *"ex1a"* ]]; then
+    printf "${GREEN}\n\nRunning KGO Update Script on ex1a.\n${NC}"
+
+    # SCP the python script to the ex1a
+    scp -q kgo_update.py umadmin@login.exz:~
+
+    # Define the commands to run on ex1a
+    command="module load scitools ; 
+             ${kgo_command_ex1a}"
+
+    # SSH to the ex1a with the run command
+    ssh -Y login.exz $command
+
+    if [[ $? -ne 0 ]]; then
+        printf "${RED}\nThe installation script has failed on ex1a.\n${NC}"
+    else
+        # rsync the generated variables file and script back to frum on linux
+        # This cleans up the original files
+        printf "${GREEN}\n\nSuccessfully installed on ex1a.\n${NC}"
+        printf "${GREEN}Rsyncing the generated files into SPICE ${variables_dir}.\n${NC}"
+        if [ $new_release -ne 1 ]; then
+            rsync --remove-source-files -avz \
+                    umadmin@login.exz:~/variables.rc_${new_kgo_dir} \
+                    ${variables_dir}/ex1a_updated_variables.rc
+        fi
+        rsync --remove-source-files -avz \
+                umadmin@login.exz:~/kgo_update_${new_kgo_dir}.sh \
+                ${variables_dir}/ex1a_update_script.sh
+    fi
+
+    # Clean up kgo_update.py on ex1a
+    ssh -Yq login.exz "rm kgo_update.py"
+fi

--- a/kgo_updates/kgo_update/meto_run_kgo_script.sh
+++ b/kgo_updates/kgo_update/meto_run_kgo_script.sh
@@ -5,9 +5,9 @@
 # which you should have received as part of this distribution.
 # *****************************COPYRIGHT*******************************
 
-# This script is intended to be run by frum having been called by 
+# This script is intended to be run by frum having been called by
 # `../meto_update_kgo.sh` . It runs the `kgo_update.py` script which it
-# assumes is in the same directory. It takes suite name, suite user, version 
+# assumes is in the same directory. It takes suite name, suite user, version
 # number, ticket number and required platforms as inputs. It runs the script on
 # each platform as required and then moves the generated variables file to
 # ~frum/kgo_updated_variables/vnVV.V_tTTTT/ on linux. IF xc40 is being run it
@@ -20,7 +20,7 @@ GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
 # Read in command line arguments
-while getopts S:U:E:N:R:P:V: flag
+while getopts S:U:E:N:R:P:V:F: flag
 do
     case "${flag}" in
         S) suite_name=${OPTARG};;
@@ -29,6 +29,7 @@ do
         N) new_kgo_dir=${OPTARG};;
         R) new_release=${OPTARG};;
         P) platforms=${OPTARG};;
+        F) variables_extension=${OPTARG};;
         V) version_number=${OPTARG};;
     esac
 done
@@ -38,12 +39,12 @@ kgo_command="./kgo_update.py"
 if [ $new_release -eq 1 ]; then
     kgo_command="${kgo_command} --new-release"
 fi
-kgo_command="${kgo_command} -S $suite_name -N $new_kgo_dir"
+kgo_command="${kgo_command} -S $suite_name -N $new_kgo_dir -E $variables_extension"
 kgo_command_spice="$kgo_command -U $suite_user -P spice"
 kgo_command_xc40="$kgo_command -U $suite_user -P xc40"
 kgo_command_ex1a="$kgo_command -U $suite_user_ex1a -P ex1a"
 
-# Make a directory to store the script and variables.rc file in
+# Make a directory to store the script and variables file file in
 variables_dir=~/kgo_update_files/vn$version_number/$new_kgo_dir
 mkdir -p $variables_dir
 
@@ -61,7 +62,7 @@ if [[ $platforms == *"spice"* ]]; then
         printf "${GREEN}\n\nSuccessfully installed on Spice.\n${NC}"
         printf "${GREEN}Moving the generated files into SPICE ${variables_dir}.${NC}\n"
         if [ $new_release -ne 1 ]; then
-            mv ~/variables.rc_${new_kgo_dir} ${variables_dir}/spice_updated_variables.rc
+            mv ~/variables${variables_extension}_${new_kgo_dir} ${variables_dir}/spice_updated_variables${variables_extension}
         fi
         mv ~/kgo_update_${new_kgo_dir}.sh ${variables_dir}/spice_update_script.sh
     fi
@@ -75,7 +76,7 @@ if [[ $platforms == *"xc40"* ]]; then
     scp -q kgo_update.py frum@xcel00:~
 
     # Define the commands to run on xc40
-    command=". /etc/profile ; module load scitools ; 
+    command=". /etc/profile ; module load scitools ;
              ${kgo_command_xc40}"
 
     # SSH to the xc40 with the run command
@@ -90,8 +91,8 @@ if [[ $platforms == *"xc40"* ]]; then
         printf "${GREEN}Rsyncing the generated files into SPICE ${variables_dir}.\n${NC}"
         if [ $new_release -ne 1 ]; then
             rsync --remove-source-files -avz \
-                frum@xcel00:~/variables.rc_${new_kgo_dir} \
-                ${variables_dir}/xc40_updated_variables.rc
+                frum@xcel00:~/variables${variables_extension}_${new_kgo_dir} \
+                ${variables_dir}/xc40_updated_variables${variables_extension}
         fi
         rsync --remove-source-files -avz \
                 frum@xcel00:~/kgo_update_${new_kgo_dir}.sh \
@@ -110,7 +111,7 @@ if [[ $platforms == *"ex1a"* ]]; then
     scp -q kgo_update.py umadmin@login.exz:~
 
     # Define the commands to run on ex1a
-    command="module load scitools ; 
+    command="module load scitools ;
              ${kgo_command_ex1a}"
 
     # SSH to the ex1a with the run command
@@ -125,8 +126,8 @@ if [[ $platforms == *"ex1a"* ]]; then
         printf "${GREEN}Rsyncing the generated files into SPICE ${variables_dir}.\n${NC}"
         if [ $new_release -ne 1 ]; then
             rsync --remove-source-files -avz \
-                    umadmin@login.exz:~/variables.rc_${new_kgo_dir} \
-                    ${variables_dir}/ex1a_updated_variables.rc
+                    umadmin@login.exz:~/variables${variables_extension}_${new_kgo_dir} \
+                    ${variables_dir}/ex1a_updated_variables${variables_extension}
         fi
         rsync --remove-source-files -avz \
                 umadmin@login.exz:~/kgo_update_${new_kgo_dir}.sh \

--- a/kgo_updates/meto_update_kgo.sh
+++ b/kgo_updates/meto_update_kgo.sh
@@ -16,6 +16,9 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
+# Move to the location of the script
+cd "$(dirname "$0")"
+
 # Check for command line argument to run with new release_mode
 new_release=0
 if [ $# -ne 0 ]; then

--- a/kgo_updates/meto_update_kgo.sh
+++ b/kgo_updates/meto_update_kgo.sh
@@ -5,25 +5,16 @@
 # which you should have received as part of this distribution.
 # *****************************COPYRIGHT*******************************
 
-# This script is intended to be run from your_working_copy/rose-stem/bin. It 
-# asks for kgo update information then moves the directory kgo_update to ~frum.
-# It then calls `run_kgo_script.sh` as frum which itself calls the update script.
-# It then moves the generated variables files back into the working copy.
-# The kg_update.py script can be run with the --new-release option by providing
+# This script will ask for kgo update information then moves the directory kgo_update
+# to ~frum. It then calls `run_kgo_script.sh` as frum which itself calls the update
+# script. It then moves the generated variables files back into the working copy.
+# The kgo_update.py script can be run with the --new-release option by providing
 # 'new-release' as a command line option to this script
 
 # Set colour codes
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
-
-# Check that the Current Working Directory is in admin/rose-stem
-cwd=$(pwd)
-if [[ $cwd != *"admin/rose-stem" ]]; then
-    printf "${RED}This script must be run from a UM working copy: admin/rose-stem.\n"
-    printf "Please move to this folder and run again.${NC}\n"
-    exit 1
-fi
 
 # Check for command line argument to run with new release_mode
 new_release=0
@@ -48,6 +39,9 @@ else
     suite_user_ex1a=None
 fi
 read -p "Suite Name: " suite_name
+read -p "Enter the path to the merged trunk WC: " wc_path
+# Trim any trailing / from the end of the path
+wc_path=${wc_path%/}
 read -p "Version Number (VV.V): " version_number
 read -p "Ticket Number (TTTT): " ticket_number
 read -p "How should the new kgo directory be named (default vn${version_number}_t${ticket_number}): " new_kgo_dir
@@ -62,6 +56,7 @@ fi
 if [[ $platforms == *"ex1a"* ]]; then
     echo "EX1A User: ${suite_user_ex1a}"
 fi
+echo "Trunk WC Path: ${wc_path}"
 echo "Version Number: ${version_number}"
 echo "Ticket Number: ${ticket_number}"
 echo "New KGO Dir: ${new_kgo_dir}"
@@ -84,7 +79,7 @@ command=". /etc/profile ; module load scitools ; cd kgo_update ;
                                   -E ${suite_user_ex1a}
                                   -N ${new_kgo_dir}
                                   -R ${new_release}
-                                  -P '${platforms}' 
+                                  -P '${platforms}'
                                   -V ${version_number} ;
          cd ~ ; rm -rf kgo_update"
 
@@ -104,7 +99,7 @@ if [[ $platforms == *"spice"* ]]; then
         if [[ $new_release -ne 1 ]]; then
             printf "${GREEN}\n\nCopying the spice variables file into this working copy.\n${NC}"
             scp -q frum@localhost:~/${variables_dir}/spice_updated_variables.rc \
-                                        ../../rose-stem/site/meto/variables_spice.rc
+                                        ${wc_path}/rose-stem/site/meto/variables_spice.rc
             if [[ $? -ne 0 ]]; then
                 printf "${RED}The copy of the spice variables.rc into this working copy has failed.\n${NC}"
                 succeeded_spice=0
@@ -122,7 +117,7 @@ if [[ $platforms == *"xc40"* ]]; then
         if [[ $new_release -ne 1 ]]; then
             printf "${GREEN}\n\nCopying the xc40 variables file into this working copy.\n${NC}"
             scp -q frum@localhost:~/${variables_dir}/xc40_updated_variables.rc \
-                                        ../../rose-stem/site/meto/variables_xc40.rc
+                                        ${wc_path}/rose-stem/site/meto/variables_xc40.rc
             if [[ $? -ne 0 ]]; then
                 printf "${RED}The copy of the xc40 variables.rc into this working copy has failed.\n${NC}"
                 succeeded_xc40=0
@@ -140,7 +135,7 @@ if [[ $platforms == *"ex1a"* ]]; then
         if [[ $new_release -ne 1 ]]; then
             printf "${GREEN}\n\nCopying the ex1a variables file into this working copy.\n${NC}"
             scp -q frum@localhost:~/${variables_dir}/ex1a_updated_variables.rc \
-                                        ../../rose-stem/site/meto/variables_ex1a.rc
+                                        ${wc_path}/rose-stem/site/meto/variables_ex1a.rc
             if [[ $? -ne 0 ]]; then
                 printf "${RED}The copy of the ex1a variables.rc into this working copy has failed.\n${NC}"
                 succeeded_ex1a=0

--- a/kgo_updates/meto_update_kgo.sh
+++ b/kgo_updates/meto_update_kgo.sh
@@ -17,7 +17,7 @@ GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
 # Move to the location of the script
-cd "$(dirname "$0")"
+script_loc="$(dirname "$0")"
 
 # Check for command line argument to run with new release_mode
 new_release=0
@@ -62,7 +62,7 @@ if [ -f "${wc_path}/rose-stem/suite.rc" ]; then
 elif [ -f "${wc_path}/rose-stem/suite.cylc" ] || [ -f "${wc_path}/rose-stem/flow.cylc" ]; then
     variables_extension=".cylc"
 else
-    printf "${RED}Couldn't detect a flow.cylc or suite.rc at ${wc_path}/rose-stem/${NC}"
+    printf "${RED}Couldn't detect a flow.cylc or suite.rc at ${wc_path}/rose-stem/\n${NC}"
     exit 1
 fi
 
@@ -90,7 +90,7 @@ if [ $run_script != "y" ]; then
 fi
 
 # Move the kgo_update directory to frum on linux
-scp -rq kgo_update frum@localhost:~
+scp -rq $script_loc/kgo_update frum@localhost:~
 
 # Define command to run as frum
 command=". /etc/profile ; module load scitools ; cd kgo_update ;

--- a/kgo_updates/meto_update_kgo.sh
+++ b/kgo_updates/meto_update_kgo.sh
@@ -42,7 +42,7 @@ else
     suite_user_ex1a=None
 fi
 read -p "Suite Name: " suite_name
-read -p "Enter the path to the merged trunk WC: " wc_path
+read -p "Enter the path to the merged trunk WC (top directory): " wc_path
 # Trim any trailing / from the end of the path
 wc_path=${wc_path%/}
 if [ ! -d "${wc_path}" ]; then
@@ -51,14 +51,20 @@ if [ ! -d "${wc_path}" ]; then
 fi
 read -p "Version Number (VV.V): " version_number
 read -p "Ticket Number (TTTT): " ticket_number
-read -p "Enter the variables file extension (.rc or .cylc (default)): " variables_extension
-variables_extension=${variables_extension:-".cylc"}
-if [[ $variables_extension != ".rc" ]] && [[ $variables_extension != ".cylc" ]]; then
-    printf "${RED}The provided variables extension '${variables_extension}' is not a valid choice (.cylc or .rc)${NC}\n"
-    exit 1
-fi
 read -p "How should the new kgo directory be named (default vn${version_number}_t${ticket_number}): " new_kgo_dir
 new_kgo_dir=${new_kgo_dir:-"vn${version_number}_t${ticket_number}"}
+
+# Check in the working_copy rose-stem for .rc or .cylc files
+# Need this for the variables file extension
+# Can't use Cylc version as .rc can be used in compatability mode
+if [ -f "${wc_path}/rose-stem/suite.rc" ]; then
+    variables_extension=".rc"
+elif [ -f "${wc_path}/rose-stem/suite.cylc" ] || [ -f "${wc_path}/rose-stem/flow.cylc" ]; then
+    variables_extension=".cylc"
+else
+    printf "${RED}Couldn't detect a flow.cylc or suite.rc at ${wc_path}/rose-stem/${NC}"
+    exit 1
+fi
 
 # Get user to double check settings
 clear

--- a/kgo_updates/meto_update_kgo.sh
+++ b/kgo_updates/meto_update_kgo.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+# *****************************COPYRIGHT*******************************
+# (C) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT.txt
+# which you should have received as part of this distribution.
+# *****************************COPYRIGHT*******************************
+
+# This script is intended to be run from your_working_copy/rose-stem/bin. It 
+# asks for kgo update information then moves the directory kgo_update to ~frum.
+# It then calls `run_kgo_script.sh` as frum which itself calls the update script.
+# It then moves the generated variables files back into the working copy.
+# The kg_update.py script can be run with the --new-release option by providing
+# 'new-release' as a command line option to this script
+
+# Set colour codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Check that the Current Working Directory is in admin/rose-stem
+cwd=$(pwd)
+if [[ $cwd != *"admin/rose-stem" ]]; then
+    printf "${RED}This script must be run from a UM working copy: admin/rose-stem.\n"
+    printf "Please move to this folder and run again.${NC}\n"
+    exit 1
+fi
+
+# Check for command line argument to run with new release_mode
+new_release=0
+if [ $# -ne 0 ]; then
+    if [[ $1 == *"new-release"* ]]; then
+        new_release=1
+    fi
+fi
+
+# Prompt user for Update Details
+echo "Enter the platforms requiring a kgo update"
+echo "Enter platforms lowercase and space separated, eg. spice xc40 ex1a"
+read platforms
+if [[ $platforms == *"spice"* ]] || [[ $platforms == *"xc40"* ]]; then
+    read -p "SPICE/XC40 Suite Username: " suite_user
+else
+    suite_user=None
+fi
+if [[ $platforms == *"ex1a"* ]]; then
+    read -p "EX1A Suite Username: " suite_user_ex1a
+else
+    suite_user_ex1a=None
+fi
+read -p "Suite Name: " suite_name
+read -p "Version Number (VV.V): " version_number
+read -p "Ticket Number (TTTT): " ticket_number
+read -p "How should the new kgo directory be named (default vn${version_number}_t${ticket_number}): " new_kgo_dir
+new_kgo_dir=${new_kgo_dir:-"vn${version_number}_t${ticket_number}"}
+
+# Get user to double check settings
+clear
+echo "Suite Name: ${suite_name}"
+if [[ $platforms == *"spice"* ]] || [[ $platforms == *"xc40"* ]]; then
+    echo "User: ${suite_user}"
+fi
+if [[ $platforms == *"ex1a"* ]]; then
+    echo "EX1A User: ${suite_user_ex1a}"
+fi
+echo "Version Number: ${version_number}"
+echo "Ticket Number: ${ticket_number}"
+echo "New KGO Dir: ${new_kgo_dir}"
+if [ $new_release -eq 1 ]; then
+    echo "WARNING: Running with --new-release enabled"
+fi
+read -p "Run with the above settings y/n (default n): " run_script
+run_script=${run_script:-n}
+if [ $run_script != "y" ]; then
+    exit 0
+fi
+
+# Move the kgo_update directory to frum on linux
+scp -rq kgo_update frum@localhost:~
+
+# Define command to run as frum
+command=". /etc/profile ; module load scitools ; cd kgo_update ;
+         ./meto_run_kgo_script.sh -S ${suite_name}
+                                  -U ${suite_user}
+                                  -E ${suite_user_ex1a}
+                                  -N ${new_kgo_dir}
+                                  -R ${new_release}
+                                  -P '${platforms}' 
+                                  -V ${version_number} ;
+         cd ~ ; rm -rf kgo_update"
+
+# Run the command as frum
+ssh -Y frum@localhost $command
+
+# Error Checking and rsyncing
+variables_dir=kgo_update_files/vn${version_number}/${new_kgo_dir}
+succeeded_spice=0
+succeeded_xc40=0
+succeeded_ex1a=0
+succeeded_all=1
+if [[ $platforms == *"spice"* ]]; then
+    file=~frum/${variables_dir}/spice_update_script.sh
+    if [[ -e "$file" ]]; then
+        succeeded_spice=1
+        if [[ $new_release -ne 1 ]]; then
+            printf "${GREEN}\n\nCopying the spice variables file into this working copy.\n${NC}"
+            scp -q frum@localhost:~/${variables_dir}/spice_updated_variables.rc \
+                                        ../../rose-stem/site/meto/variables_spice.rc
+            if [[ $? -ne 0 ]]; then
+                printf "${RED}The copy of the spice variables.rc into this working copy has failed.\n${NC}"
+                succeeded_spice=0
+                succeeded_all=0
+            fi
+        fi
+    else
+        succeeded_all=0
+    fi
+fi
+if [[ $platforms == *"xc40"* ]]; then
+    file=~frum/${variables_dir}/xc40_update_script.sh
+    if [[ -e "$file" ]]; then
+        succeeded_xc40=1
+        if [[ $new_release -ne 1 ]]; then
+            printf "${GREEN}\n\nCopying the xc40 variables file into this working copy.\n${NC}"
+            scp -q frum@localhost:~/${variables_dir}/xc40_updated_variables.rc \
+                                        ../../rose-stem/site/meto/variables_xc40.rc
+            if [[ $? -ne 0 ]]; then
+                printf "${RED}The copy of the xc40 variables.rc into this working copy has failed.\n${NC}"
+                succeeded_xc40=0
+                succeeded_all=0
+            fi
+        fi
+    else
+        succeeded_all=0
+    fi
+fi
+if [[ $platforms == *"ex1a"* ]]; then
+    file=~frum/${variables_dir}/ex1a_update_script.sh
+    if [[ -e "$file" ]]; then
+        succeeded_ex1a=1
+        if [[ $new_release -ne 1 ]]; then
+            printf "${GREEN}\n\nCopying the ex1a variables file into this working copy.\n${NC}"
+            scp -q frum@localhost:~/${variables_dir}/ex1a_updated_variables.rc \
+                                        ../../rose-stem/site/meto/variables_ex1a.rc
+            if [[ $? -ne 0 ]]; then
+                printf "${RED}The copy of the ex1a variables.rc into this working copy has failed.\n${NC}"
+                succeeded_ex1a=0
+                succeeded_all=0
+            fi
+        fi
+    else
+        succeeded_all=0
+    fi
+fi
+
+if [[ $succeeded_all -eq 1 ]]; then
+    printf "${GREEN}All kgo has been successfully installed.\n${NC}"
+else
+    printf "${RED}\n\nAt least 1 platform suffered an error during installation.\n${NC}"
+fi
+
+# For the xc40s rsync the generated kgo to the xcs
+if [[ $succeeded_xc40 -eq 1 ]]; then
+    printf "${GREEN}\n\nrsyncing the kgo to xcs.\n${NC}"
+    rsync_com="ssh -Y xcel00 'rsync -av /projects/um1/standard_jobs/kgo/ xcslr0:/common/um1/standard_jobs/kgo/'"
+    ssh -Y frum@localhost $rsync_com
+    if [[ $? -ne 0 ]]; then
+        printf "${RED}The rsync to the xcs has failed.\n${NC}"
+    else
+        printf "${Green}The rsync to the xcs has succeeded.\n${NC}"
+    fi
+elif [[ $platforms == *"xc40"* ]]; then
+    printf "${RED}\n\nSkipping the rsync to the xcs as the xc40 install failed.\n${NC}"
+fi
+
+printf "\n\nInstallation Summary:\n\n"
+if [[ $platforms == *"spice"* ]]; then
+    if [[ $succeeded_spice -eq 1 ]]; then
+        printf "${GREEN}Installation on spice successful.\n${NC}"
+    else
+        printf "${RED}Installation on spice unsuccessful. Review output for error.\n${NC}"
+    fi
+fi
+if [[ $platforms == *"xc40"* ]]; then
+    if [[ $succeeded_xc40 -eq 1 ]]; then
+        printf "${GREEN}Installation on xc40 successful.\n${NC}"
+    else
+        printf "${RED}Installation on xc40 unsuccessful. Review output for error.\n${NC}"
+    fi
+fi
+if [[ $platforms == *"ex1a"* ]]; then
+    if [[ $succeeded_ex1a -eq 1 ]]; then
+        printf "${GREEN}Installation on ex1a successful.\n${NC}"
+    else
+        printf "${RED}Installation on ex1a unsuccessful. Review output for error.\n${NC}"
+    fi
+fi

--- a/kgo_updates/meto_update_kgo.sh
+++ b/kgo_updates/meto_update_kgo.sh
@@ -168,7 +168,13 @@ fi
 # For the xc40s rsync the generated kgo to the xcs
 if [[ $succeeded_xc40 -eq 1 ]]; then
     printf "${GREEN}\n\nrsyncing the kgo to xcs.\n${NC}"
-    rsync_com="ssh -Y xcel00 'rsync -av /projects/um1/standard_jobs/kgo/ xcslr0:/common/um1/standard_jobs/kgo/'"
+    read -p "Enter 1 to rsync UM KGO, 2 to rsync lfricinputs KGO (default 1): " rsync_type
+    if [[ $rsync_type == "2" ]]; then
+        rsync_dir="lfricinputs/kgo/"
+    else
+        rsync_dir="kgo/"
+    fi
+    rsync_com="ssh -Y xcel00 'rsync -av /projects/um1/standard_jobs/${rsync_dir} xcslr0:/common/um1/standard_jobs/${rsync_dir}'"
     ssh -Y frum@localhost $rsync_com
     if [[ $? -ne 0 ]]; then
         printf "${RED}The rsync to the xcs has failed.\n${NC}"

--- a/kgo_updates/meto_update_kgo.sh
+++ b/kgo_updates/meto_update_kgo.sh
@@ -42,8 +42,18 @@ read -p "Suite Name: " suite_name
 read -p "Enter the path to the merged trunk WC: " wc_path
 # Trim any trailing / from the end of the path
 wc_path=${wc_path%/}
+if [ ! -d "${wc_path}" ]; then
+    printf "${RED}${wc_path} is not a valid path${NC}\n"
+    exit 1
+fi
 read -p "Version Number (VV.V): " version_number
 read -p "Ticket Number (TTTT): " ticket_number
+read -p "Enter the variables file extension (.rc or .cylc (default)): " variables_extension
+variables_extension=${variables_extension:-".cylc"}
+if [[ $variables_extension != ".rc" ]] && [[ $variables_extension != ".cylc" ]]; then
+    printf "${RED}The provided variables extension '${variables_extension}' is not a valid choice (.cylc or .rc)${NC}\n"
+    exit 1
+fi
 read -p "How should the new kgo directory be named (default vn${version_number}_t${ticket_number}): " new_kgo_dir
 new_kgo_dir=${new_kgo_dir:-"vn${version_number}_t${ticket_number}"}
 
@@ -59,6 +69,7 @@ fi
 echo "Trunk WC Path: ${wc_path}"
 echo "Version Number: ${version_number}"
 echo "Ticket Number: ${ticket_number}"
+echo "Variables Extension: ${variables_extension}"
 echo "New KGO Dir: ${new_kgo_dir}"
 if [ $new_release -eq 1 ]; then
     echo "WARNING: Running with --new-release enabled"
@@ -80,6 +91,7 @@ command=". /etc/profile ; module load scitools ; cd kgo_update ;
                                   -N ${new_kgo_dir}
                                   -R ${new_release}
                                   -P '${platforms}'
+                                  -F ${variables_extension}
                                   -V ${version_number} ;
          cd ~ ; rm -rf kgo_update"
 
@@ -98,10 +110,10 @@ if [[ $platforms == *"spice"* ]]; then
         succeeded_spice=1
         if [[ $new_release -ne 1 ]]; then
             printf "${GREEN}\n\nCopying the spice variables file into this working copy.\n${NC}"
-            scp -q frum@localhost:~/${variables_dir}/spice_updated_variables.rc \
-                                        ${wc_path}/rose-stem/site/meto/variables_spice.rc
+            scp -q frum@localhost:~/${variables_dir}/spice_updated_variables${variables_extension} \
+                                        ${wc_path}/rose-stem/site/meto/variables_spice${variables_extension}
             if [[ $? -ne 0 ]]; then
-                printf "${RED}The copy of the spice variables.rc into this working copy has failed.\n${NC}"
+                printf "${RED}The copy of the spice variables file into this working copy has failed.\n${NC}"
                 succeeded_spice=0
                 succeeded_all=0
             fi
@@ -116,10 +128,10 @@ if [[ $platforms == *"xc40"* ]]; then
         succeeded_xc40=1
         if [[ $new_release -ne 1 ]]; then
             printf "${GREEN}\n\nCopying the xc40 variables file into this working copy.\n${NC}"
-            scp -q frum@localhost:~/${variables_dir}/xc40_updated_variables.rc \
-                                        ${wc_path}/rose-stem/site/meto/variables_xc40.rc
+            scp -q frum@localhost:~/${variables_dir}/xc40_updated_variables${variables_extension} \
+                                        ${wc_path}/rose-stem/site/meto/variables_xc40${variables_extension}
             if [[ $? -ne 0 ]]; then
-                printf "${RED}The copy of the xc40 variables.rc into this working copy has failed.\n${NC}"
+                printf "${RED}The copy of the xc40 variables file into this working copy has failed.\n${NC}"
                 succeeded_xc40=0
                 succeeded_all=0
             fi
@@ -134,10 +146,10 @@ if [[ $platforms == *"ex1a"* ]]; then
         succeeded_ex1a=1
         if [[ $new_release -ne 1 ]]; then
             printf "${GREEN}\n\nCopying the ex1a variables file into this working copy.\n${NC}"
-            scp -q frum@localhost:~/${variables_dir}/ex1a_updated_variables.rc \
-                                        ${wc_path}/rose-stem/site/meto/variables_ex1a.rc
+            scp -q frum@localhost:~/${variables_dir}/ex1a_updated_variables${variables_extension} \
+                                        ${wc_path}/rose-stem/site/meto/variables_ex1a${variables_extension}
             if [[ $? -ne 0 ]]; then
-                printf "${RED}The copy of the ex1a variables.rc into this working copy has failed.\n${NC}"
+                printf "${RED}The copy of the ex1a variables file into this working copy has failed.\n${NC}"
                 succeeded_ex1a=0
                 succeeded_all=0
             fi


### PR DESCRIPTION
These changes allow the kgo update scripts to work with cylc 7 and cylc8. There are changes to allow the scripts to find variables*.cylc files as well as variables*.rc files and for the wrapper shell scripts to work for lfricinputs kgo installation as well as for UM. 

The first commit is a straight copy of the scripts from the UM trunk.