### PR TITLE
Update UKCA University of Cambridge template to match date regex

### DIFF
--- a/script_copyright_checker/file/UKCA_Cam.regex_template
+++ b/script_copyright_checker/file/UKCA_Cam.regex_template
@@ -1,0 +1,9 @@
+! \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*COPYRIGHT\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*
+!
+! \(c\) \[University of Cambridge\] \[20[1234567890]{2}\]\. All rights reserved\.
+! This routine has been licensed to the Met Office for use and
+! distribution under the UKCA collaboration agreement, subject
+! to the terms and conditions set out therein\.
+! \[Met Office Ref SC138\]
+!
+! \*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*COPYRIGHT\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*

--- a/script_copyright_checker/file/UKCA_cam2.template
+++ b/script_copyright_checker/file/UKCA_cam2.template
@@ -1,9 +1,0 @@
-! *****************************COPYRIGHT*******************************
-!
-! (c) [University of Cambridge] [2008]. All rights reserved.
-! This routine has been licensed to the Met Office for use and
-! distribution under the UKCA collaboration agreement, subject
-! to the terms and conditions set out therein.
-! [Met Office Ref SC138]
-!
-! *****************************COPYRIGHT*******************************


### PR DESCRIPTION
This change removes the `UKCA_cam2.template` template and adds an equivalent Regex one that accepts alternative copyright years.

Fixes #17 