### PR TITLE
Add nightly retrigger script

### DIFF
--- a/kgo_updates/meto_update_kgo.sh
+++ b/kgo_updates/meto_update_kgo.sh
@@ -210,6 +210,7 @@ if [[ $succeeded_ex1a -eq 1 ]]; then
         printf "${RED}The rsync to the exa has failed.\n${NC}"
     else
         printf "${Green}The rsync to the exa has succeeded.\n${NC}"
+    fi
 elif [[ $platforms == *"ex1a"* ]]; then
     printf "${RED}\n\nSkipping the rsync to the exa as the exz install failed.\n${NC}"
 fi

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Script which to generate a cron file for run nightly testing from.
+Script to generate a cron file, from which nightly testing is run.
 Cron jobs are based on a provided yaml config file (-c command line option) and
 the resulting cron file is installed if the --install option is added.
 See https://metoffice.github.io/simulation-systems/Reviewers/nightlytesting.html

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """
-Script which launches a rose-stem suite.
+Script which to generate a cron file for run nightly testing from.
+Cron jobs are based on a provided yaml config file (-c command line option) and
+the resulting cron file is installed if the --install option is added.
+See https://metoffice.github.io/simulation-systems/Reviewers/nightlytesting.html
 Used for nightly testing for UM, Jules, UKCA, LFRic_Apps
 Compatible for both Cylc7 + Cylc8
 
@@ -52,7 +55,7 @@ CYLC_DIFFS = {
         "clean": "cylc clean --timeout=7200",
     },
 }
-WC_DIR = "/tmp/frzz"
+WC_DIR = f"/tmp/{os.getlogin()}"
 UMDIR = os.environ["UMDIR"]
 PROFILE = ". /etc/profile"
 DATE_BASE = "date +\\%Y-\\%m-\\%d"
@@ -117,15 +120,14 @@ def generate_cron_timing_str(suite, mode):
     """
 
     if mode == "monitoring":
-        cron = f"{MONITORING_TIME} * * "
+        cron = f"{MONITORING_TIME}"
+    elif mode == "main":
+        cron = suite["cron_launch"]
+    elif mode == "clean":
+        cron = suite["cron_clean"]
     else:
-        if mode == "main":
-            cron = suite["cron_launch"]
-        elif mode == "clean":
-            cron = suite["cron_clean"]
-        else:
-            sys.exit("Unrecognised mode for cron timing string")
-        cron += " * * "
+        sys.exit("Unrecognised mode for cron timing string")
+    cron += " * * "
 
     if suite["period"] == "weekly":
         if mode == "main" or mode == "monitoring":

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Script which launches a rose-stem suite.
 Used for nightly testing for UM, Jules, UKCA, LFRic_Apps

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Scan a users (inteded as frzz for nightly testing) cylc-run directory for
+cylc8 suites with uncompleted tasks
+Restart each found and retrigger failed/submit-failed tasks
+"""
+
+import os
+import re
+import subprocess
+import sqlite3
+from datetime import datetime, timedelta
+
+
+def run_command(command):
+    """
+    Launch a subprocess command and return the output
+    """
+    result = subprocess.run(command.split(), capture_output=True, text=True)
+    return result
+
+
+def connect_to_kgo_database(suite_dir):
+    """
+    Make a connection to the suite database
+    """
+    db_filename = os.path.join(suite_dir, "log", "db")
+    if not os.path.exists(db_filename):
+        print(f"Warning: Suite database not found at {db_filename}")
+        return None
+    return sqlite3.connect(db_filename)
+
+
+def check_suite_cylc8(conn):
+    """
+    Search the DB for a "workflow_params" table - if it exists this is a cylc8
+    suite so return False
+    """
+    res = conn.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='workflow_params'"
+    ).fetchall()
+    if len(res) > 0:
+        return True
+    return False
+
+
+def check_for_failed_tasks(conn):
+    """
+    Search for tasks in table "task_state" with failed in status
+    If any exist return True, else False
+    """
+    res = conn.execute(
+        "SELECT name, status FROM task_states WHERE status LIKE '%failed%'"
+    ).fetchall()
+    if len(res) > 0:
+        return True
+    return False
+
+
+def ask_yn(message):
+    """
+    Ask a message with yes or no options
+    Return True for y, False for n
+    """
+    rval = ""
+    while rval not in ["y", "n"]:
+        rval = input(f"{message}? (y/n) ")
+    return {"y": True, "n": False}[rval]
+
+
+def restart_suite(suite):
+    """
+    Generate and run the command to restart the suite
+    """
+    print(f"Restarting {suite}")
+    play_command = f"cylc play -q {suite}"
+    _ = run_command(play_command)
+
+
+def retrigger_suite(suite):
+    """
+    Generate and run commands to retrigger failed and submit-failed tasks
+    """
+    failed_command = f"cylc trigger {suite}//*:failed"
+    subfail_command = f"cylc trigger {suite}//*:submit-failed"
+    print(f"Triggering Failed Tasks in {suite}")
+    _ = run_command(failed_command)
+    print(f"Triggering Submit-Failed Tasks in {suite}")
+    _ = run_command(subfail_command)
+
+
+if __name__ == "__main__":
+    # Get the current date
+    today = datetime.now()
+    # If Monday then include suites from the weekend, otherwise just today
+    if today.weekday() == 0:
+        day_delta = 2
+    else:
+        day_delta = 1
+
+    # Get a list of suites from the last day(weekend) to check for failed tasks
+    valid_suites = []
+    cylc_run = os.path.expanduser(os.path.join("~frzz", "cylc-run"))
+    for suite in os.listdir(cylc_run):
+        # Get the date string from the suite name - if not present then skip
+        try:
+            date_str = re.findall(r"\d{4}-\d{2}-\d{2}", suite)[0]
+        except IndexError:
+            continue
+        # Convert to datetime and compare with day difference
+        suite_date = datetime.strptime(date_str, "%Y-%m-%d")
+        if suite_date > today - timedelta(days=day_delta):
+            valid_suites.append(suite)
+
+    # Parse the valid_suites for ones which are cylc8 and have failed tasks
+    failed_suites = []
+    for suite in valid_suites:
+        suite_dir = os.path.join(cylc_run, suite, "runN")
+        conn = connect_to_kgo_database(suite_dir)
+        if conn is None or not check_suite_cylc8(conn):
+            continue
+        if check_for_failed_tasks(conn):
+            failed_suites.append(suite)
+
+    print("\nFound the following suites with errors:")
+    for suite in failed_suites:
+        print(f"    * {suite}")
+    print()
+
+    # Restart failed suites
+    run_all = ask_yn("Do you want to restart all failed suites")
+    for suite in failed_suites:
+        if not run_all and not ask_yn(f"Do you want to restart {suite}"):
+            continue
+        restart_suite(suite)
+        retrigger_suite(suite)

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -86,10 +86,13 @@ def retrigger_suite(suite, tasks):
     """
     Generate and run commands to retrigger failed and submit-failed tasks
     """
-    print(f"Triggering Failed Tasks in {suite}")
-    for task in tasks:
+    print(f"\nTriggering Failed Tasks in {suite}")
+    ntasks = len(tasks)
+    for i, task in enumerate(tasks):
+        print(f"\rTask {i}/{ntasks}", end="", flush=True)
         failed_command = f"cylc trigger {suite}//*/{task[0]}"
         _ = run_command(failed_command)
+    print()
 
 
 if __name__ == "__main__":

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -48,8 +48,8 @@ def check_suite_cylc8(conn):
 
 def check_for_failed_tasks(conn):
     """
-    Search for tasks in table "task_state" with failed in status
-    If any exist return True, else False
+    Search for tasks in table "task_state" with failed or submit-failed status
+    Return a list of these tasks
     """
     res_failed = conn.execute(
         "SELECT name, status FROM task_states WHERE status LIKE '%failed%'"

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -83,11 +83,8 @@ def retrigger_suite(suite):
     Generate and run commands to retrigger failed and submit-failed tasks
     """
     failed_command = f"cylc trigger {suite}//*:failed"
-    subfail_command = f"cylc trigger {suite}//*:submit-failed"
     print(f"Triggering Failed Tasks in {suite}")
     _ = run_command(failed_command)
-    print(f"Triggering Submit-Failed Tasks in {suite}")
-    _ = run_command(subfail_command)
 
 
 if __name__ == "__main__":
@@ -130,8 +127,13 @@ if __name__ == "__main__":
 
     # Restart failed suites
     run_all = ask_yn("Do you want to restart all failed suites")
+    restarted_suites = []
     for suite in failed_suites:
         if not run_all and not ask_yn(f"Do you want to restart {suite}"):
             continue
         restart_suite(suite)
+        restarted_suites.append(suite)
+
+    # Retrigger failed tasks
+    for suite in restarted_suites:
         retrigger_suite(suite)

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -3,6 +3,10 @@
 Scan a users (inteded as frzz for nightly testing) cylc-run directory for
 cylc8 suites with uncompleted tasks
 Restart each found and retrigger failed/submit-failed tasks
+Can pass names of suites as posiional arguments. Doesn't need to be entire name,
+eg. passing lfric_apps will retrigger any suite with lfric_apps in the name
+Syntax:
+    python retrigger_nightlies.py [suite_name1 suite_name2 ...]
 """
 
 import os

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -82,7 +82,7 @@ def retrigger_suite(suite):
     """
     Generate and run commands to retrigger failed and submit-failed tasks
     """
-    failed_command = f"cylc trigger {suite}/*/*:failed"
+    failed_command = f"cylc trigger {suite}//*:failed"
     print(f"Triggering Failed Tasks in {suite}")
     _ = run_command(failed_command)
 
@@ -136,5 +136,5 @@ if __name__ == "__main__":
     print()
 
     # Retrigger failed tasks
-    for suite in restarted_suites:
-        retrigger_suite(suite)
+    # for suite in restarted_suites:
+    #     retrigger_suite(suite)

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -135,6 +135,6 @@ if __name__ == "__main__":
         restarted_suites.append(suite)
     print()
 
-    Retrigger failed tasks
+    # Retrigger failed tasks
     for suite in restarted_suites:
         retrigger_suite(suite)

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -3,8 +3,9 @@
 Scan a users (inteded as frzz for nightly testing) cylc-run directory for
 cylc8 suites with uncompleted tasks
 Restart each found and retrigger failed/submit-failed tasks
-Can pass names of suites as posiional arguments. Doesn't need to be entire name,
-eg. passing lfric_apps will retrigger any suite with lfric_apps in the name
+Can pass names of suites as positional arguments.
+Doesn't need to be entire name, eg. passing lfric_apps will retrigger any suite
+with lfric_apps in the name
 Syntax:
     python retrigger_nightlies.py [suite_name1 suite_name2 ...]
 """
@@ -40,7 +41,7 @@ def connect_to_database(suite_dir):
 def check_suite_cylc8(conn):
     """
     Search the DB for a "workflow_params" table - if it exists this is a cylc8
-    suite so return False
+    suite so return True
     """
     res = conn.execute(
         "SELECT name FROM sqlite_master "

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -88,7 +88,7 @@ def retrigger_suite(suite, tasks):
     print(f"\nTriggering Failed Tasks in {suite}")
     ntasks = len(tasks)
     for i, task in enumerate(tasks):
-        print(f"\rTask {i}/{ntasks}", end="", flush=True)
+        print(f"\rTask {i+1}/{ntasks}", end="", flush=True)
         failed_command = f"cylc trigger {suite}//*/{task[0]}"
         _ = run_command(failed_command)
     print()

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -6,6 +6,7 @@ Restart each found and retrigger failed/submit-failed tasks
 """
 
 import os
+import sys
 import re
 import subprocess
 import sqlite3
@@ -95,6 +96,11 @@ def retrigger_suite(suite, tasks):
 
 
 if __name__ == "__main__":
+    # If names to restart are specified then record list of them here
+    restart_names = []
+    if len(sys.argv) > 1:
+        restart_names = sys.argv[1:]
+
     # Get the current date
     today = datetime.now()
     # If Monday then include suites from the weekend, otherwise just today
@@ -107,6 +113,14 @@ if __name__ == "__main__":
     valid_suites = []
     cylc_run = os.path.expanduser(os.path.join("~frzz", "cylc-run"))
     for suite in os.listdir(cylc_run):
+        # If restart names are defined then check whether this suite matches any
+        # If not found then continue and don't restart the suite
+        if restart_names:
+            for wanted in restart_names:
+                if wanted in suite:
+                    break
+            else:
+                continue
         # Get the date string from the suite name - if not present then skip
         try:
             date_str = re.findall(r"\d{4}-\d{2}-\d{2}", suite)[0]

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -10,7 +10,6 @@ import re
 import subprocess
 import sqlite3
 from time import sleep
-from datetime import datetime
 from datetime import datetime, timedelta
 
 

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -136,5 +136,5 @@ if __name__ == "__main__":
     print()
 
     # Retrigger failed tasks
-    for suite in restarted_suites:
-        retrigger_suite(suite)
+    # for suite in restarted_suites:
+    #     retrigger_suite(suite)

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -133,6 +133,7 @@ if __name__ == "__main__":
             continue
         restart_suite(suite)
         restarted_suites.append(suite)
+    print()
 
     # Retrigger failed tasks
     for suite in restarted_suites:

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -82,7 +82,7 @@ def retrigger_suite(suite):
     """
     Generate and run commands to retrigger failed and submit-failed tasks
     """
-    failed_command = f"cylc trigger {suite}//*:failed"
+    failed_command = f"cylc trigger {suite}/*/*:failed"
     print(f"Triggering Failed Tasks in {suite}")
     _ = run_command(failed_command)
 
@@ -135,6 +135,6 @@ if __name__ == "__main__":
         restarted_suites.append(suite)
     print()
 
-    # Retrigger failed tasks
-    # for suite in restarted_suites:
-    #     retrigger_suite(suite)
+    Retrigger failed tasks
+    for suite in restarted_suites:
+        retrigger_suite(suite)

--- a/nightly_testing/tests/test_generate_test_suite_cron.py
+++ b/nightly_testing/tests/test_generate_test_suite_cron.py
@@ -28,15 +28,16 @@ def test_join_checkout_commands(inlist, scratch, expected):
 data_lfric_heads_sed = [
     (
         "path/to/wc",
-        "sed -i -e 's/^\\(export .*_revision=@\\).*/\\1HEAD/' path/to/wc/dependencies.sh ; sed -i -e 's/^\\(export .*_rev=\\).*/\\1HEAD/' path/to/wc/dependencies.sh ; "
+        "cp -r path/to/wc path/to/wc_heads ; sed -i -e 's/^\\(export .*_revision=@\\).*/\\1HEAD/' path/to/wc_heads/dependencies.sh ; sed -i -e 's/^\\(export .*_rev=\\).*/\\1HEAD/' path/to/wc_heads/dependencies.sh ; ",
+        "path/to/wc_heads"
     )
 ]
 @pytest.mark.parametrize(
-    ("wc_path", "expected"),
+    ("wc_path", "expected", "new_wc"),
     [test_data for test_data in data_lfric_heads_sed]
 )
-def test_lfric_heads_sed(wc_path, expected):
-    assert lfric_heads_sed(wc_path) == expected
+def test_lfric_heads_sed(wc_path, expected, new_wc):
+    assert lfric_heads_sed(wc_path) == (expected, new_wc)
 
 
 # Test generate_cron_timing_str


### PR DESCRIPTION
A script to automatically relaunch and retrigger suites during meto nightly testing.

This PR also edits the generate script to set lfric apps heads testing to use a new working copy as the heads step edits the working copy. Updates relevant unit test for this.

Linked to MetOffice/simulation-systems#159