### PR TITLE
change wc loc

### DIFF
--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -51,7 +51,7 @@ CYLC_DIFFS = {
         "clean": "cylc clean --timeout=7200",
     },
 }
-WC_DIR = "/tmp/frzz"
+WC_DIR = os.path.join(os.environ["TMPDIR"], os.environ["USER"])
 UMDIR = os.environ["UMDIR"]
 PROFILE = ". /etc/profile"
 DATE_BASE = "date +\\%Y-\\%m-\\%d"


### PR DESCRIPTION
The adjoint tests builds are failing when launched from a cronjob with the working copy in /tmp. While the actual reason for this is investigated we'll launch from $TMPDIR instead which seems to work. Linked with [LFRic_Apps:#44](https://code.metoffice.gov.uk/trac/lfric_apps/ticket/44)