### PR TITLE
Next cylc nightly

### DIFF
--- a/nightly_testing/example_meto_configs.yaml
+++ b/nightly_testing/example_meto_configs.yaml
@@ -154,6 +154,19 @@ um_set-revisions_nightly_cylc7:
     period: nightly_all
 
 
+um_set-revisions_nightly_next-cylc:
+    repo: um
+    groups: developer,ex1a_developer
+    use_next_cylc: 8-next
+    revisions: set
+    vars:
+        - HOUSEKEEPING=false
+        - PREBUILDS=false
+    time_launch: 03:00
+    time_clean: 02:00
+    period: nightly_all
+
+
 #################
 # Jules Configs #
 #################

--- a/nightly_testing/example_meto_configs.yaml
+++ b/nightly_testing/example_meto_configs.yaml
@@ -157,7 +157,7 @@ um_set-revisions_nightly_cylc7:
 um_set-revisions_nightly_next-cylc:
     repo: um
     groups: developer,ex1a_developer
-    use_next_cylc: 8-next
+    cylc_version: 8-next
     revisions: set
     vars:
         - HOUSEKEEPING=false

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -22,8 +22,6 @@ Optional:
 * vars: strings that follow the -S command on the command line
 * monitoring: Boolean, whether to run the monitoring script on this suite
 * cylc_version: 7 or 8
-* use_next_cylc: String, if defined will use this string after export
-  CYLC_VERSION=. Intended to test the 'next' version of cylc
 """
 
 import os
@@ -198,25 +196,13 @@ def generate_monitoring(name, suite, log_file):
     return monitoring + "\n"
 
 
-def export_cylc_string(suite, cylc_version):
-    """
-    Based on the cylc version and the use_next_cylc setting return the version
-    string to export
-    """
-
-    if "use_next_cylc" not in suite or not suite["use_next_cylc"]:
-        return cylc_version
-    else:
-        return suite["use_next_cylc"]
-
-
-def generate_clean_commands(suite, cylc_version, name, log_file):
+def generate_clean_commands(cylc_version, name, log_file):
     """
     Generate the commands used to clean the suite
     """
     return (
         f"{PROFILE} ; "
-        f"export CYLC_VERSION={export_cylc_string(suite, cylc_version)} ; "
+        f"export CYLC_VERSION={cylc_version} ; "
         f"cylc stop '{name}' >/dev/null 2>&1 ; sleep 10 ; "
         f"{CYLC_DIFFS[cylc_version]['clean']} -y -q {name} "
         f">> {log_file} 2>&1\n"
@@ -237,7 +223,7 @@ def generate_clean_cron(suite_name, suite, log_file, cylc_version):
 
     name = suite_name + date_str
 
-    clean_cron += generate_clean_commands(suite, cylc_version, name, log_file)
+    clean_cron += generate_clean_commands(cylc_version, name, log_file)
 
     return clean_cron
 
@@ -249,7 +235,7 @@ def generate_rose_stem_command(suite, wc_path, cylc_version, name):
     """
 
     return (
-        f"export CYLC_VERSION={export_cylc_string(suite, cylc_version)} ; "
+        f"export CYLC_VERSION={cylc_version} ; "
         + f"rose stem --group={suite['groups']} "
         + f"{CYLC_DIFFS[cylc_version]['name']}{name} "
         + f"--source={wc_path} "

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -196,13 +196,26 @@ def generate_monitoring(name, suite, log_file):
     return monitoring + "\n"
 
 
-def generate_clean_commands(cylc_version, name, log_file):
+def export_cylc_string(suite, cylc_version):
+    """
+    Based on the cylc version and the use_next_cylc setting return the version
+    string to export
+    Assumes the next cylc version is loaded with 'export CYLC_VERSION=8-next'
+    """
+
+    if "use_next_cylc" not in suite or not suite["use_next_cylc"]:
+        return cylc_version
+    else:
+        return suite["use_next_cylc"]
+
+
+def generate_clean_commands(suite, cylc_version, name, log_file):
     """
     Generate the commands used to clean the suite
     """
     return (
         f"{PROFILE} ; "
-        f"export CYLC_VERSION={cylc_version} ; "
+        f"export CYLC_VERSION={export_cylc_string(suite, cylc_version)} ; "
         f"cylc stop '{name}' >/dev/null 2>&1 ; sleep 10 ; "
         f"{CYLC_DIFFS[cylc_version]['clean']} -y -q {name} "
         f">> {log_file} 2>&1\n"
@@ -223,7 +236,7 @@ def generate_clean_cron(suite_name, suite, log_file, cylc_version):
 
     name = suite_name + date_str
 
-    clean_cron += generate_clean_commands(cylc_version, name, log_file)
+    clean_cron += generate_clean_commands(suite, cylc_version, name, log_file)
 
     return clean_cron
 
@@ -235,7 +248,7 @@ def generate_rose_stem_command(suite, wc_path, cylc_version, name):
     """
 
     return (
-        f"export CYLC_VERSION={cylc_version} ; "
+        f"export CYLC_VERSION={export_cylc_string(suite, cylc_version)} ; "
         + f"rose stem --group={suite['groups']} "
         + f"{CYLC_DIFFS[cylc_version]['name']}{name} "
         + f"--source={wc_path} "

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -74,6 +74,16 @@ def run_command(command):
     )
 
 
+def major_cylc_version(cylc_version):
+    """
+    Return the major version of cylc being requested by cylc_version
+    Expected to be 7 or 8
+    """
+    if type(cylc_version) == int:
+        return cylc_version
+    return int(cylc_version[0])
+
+
 def join_checkout_commands(repos, dir_wc):
     """
     Join commands that checkout new repos
@@ -208,7 +218,7 @@ def generate_clean_commands(cylc_version, name, log_file):
         f"{PROFILE} ; "
         f"export CYLC_VERSION={cylc_version} ; "
         f"cylc stop '{name}' >/dev/null 2>&1 ; sleep 10 ; "
-        f"{CYLC_DIFFS[int(cylc_version[0])]['clean']} -y -q {name} "
+        f"{CYLC_DIFFS[major_cylc_version(cylc_version)]['clean']} -y -q {name} "
         f">> {log_file} 2>&1\n"
     )
 
@@ -241,7 +251,7 @@ def generate_rose_stem_command(suite, wc_path, cylc_version, name):
     return (
         f"export CYLC_VERSION={cylc_version} ; "
         + f"rose stem --group={suite['groups']} "
-        + f"{CYLC_DIFFS[int(cylc_version[0])]['name']}{name} "
+        + f"{CYLC_DIFFS[major_cylc_version(cylc_version)]['name']}{name} "
         + f"--source={wc_path} "
     )
 
@@ -307,7 +317,7 @@ def generate_main_job(name, suite, log_file, wc_path, cylc_version):
 
     cron_job += f">> {log_file} 2>&1"
 
-    if int(cylc_version[0]) == 8:
+    if major_cylc_version(cylc_version) == 8:
         cron_job += f" ; cylc play {name} >> {log_file} 2>&1"
 
     return cron_job + "\n"

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# *****************************COPYRIGHT*******************************
+# (C) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT.txt
+# which you should have received as part of this distribution.
+# *****************************COPYRIGHT*******************************
+
 """
 Script to generate a cron file, from which nightly testing is run.
 Cron jobs are based on a provided yaml config file (-c command line option) and

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -111,7 +111,7 @@ def lfric_heads_sed(wc_path):
     wc_path_new = wc_path + "_heads"
     dep_path = os.path.join(wc_path_new, "dependencies.sh")
 
-    rstr = f"cp -r {wc_path} {wc_path_new} ; "
+    rstr = f"cp -rf {wc_path} {wc_path_new} ; "
     rstr += f"sed -i -e 's/^\\(export .*_revision=@\\).*/\\1HEAD/' {dep_path} ; "
     rstr += f"sed -i -e 's/^\\(export .*_rev=\\).*/\\1HEAD/' {dep_path} ; "
     return rstr, wc_path_new

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -34,6 +34,7 @@ Optional:
 
 import os
 import sys
+import re
 import yaml
 import argparse
 import subprocess
@@ -54,11 +55,11 @@ DEPENDENCIES = {
     "ukca": [],
 }
 CYLC_DIFFS = {
-    7: {
+    "7": {
         "name": "--name=",
         "clean": "rose suite-clean",
     },
-    8: {
+    "8": {
         "name": "--workflow-name=",
         "clean": "cylc clean --timeout=7200",
     },
@@ -85,9 +86,7 @@ def major_cylc_version(cylc_version):
     Return the major version of cylc being requested by cylc_version
     Expected to be 7 or 8
     """
-    if type(cylc_version) == int:
-        return cylc_version
-    return int(cylc_version[0])
+    return re.split("[._-]", cylc_version)[0]
 
 
 def join_checkout_commands(repos, dir_wc):
@@ -130,7 +129,9 @@ def lfric_heads_sed(wc_path):
     dep_path = os.path.join(wc_path_new, "dependencies.sh")
 
     rstr = f"cp -rf {wc_path} {wc_path_new} ; "
-    rstr += f"sed -i -e 's/^\\(export .*_revision=@\\).*/\\1HEAD/' {dep_path} ; "
+    rstr += (
+        f"sed -i -e 's/^\\(export .*_revision=@\\).*/\\1HEAD/' {dep_path} ; "
+    )
     rstr += f"sed -i -e 's/^\\(export .*_rev=\\).*/\\1HEAD/' {dep_path} ; "
     return rstr
 
@@ -238,7 +239,6 @@ def generate_clean_cron(suite_name, suite, log_file, cylc_version):
     if suite["period"] == "weekly":
         date_str = f'_$({DATE_BASE} -d "6 days ago")'
     else:
-
         date_str = f'_$({DATE_BASE} -d "1 day ago")'
 
     name = suite_name + date_str

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -22,6 +22,8 @@ Optional:
 * vars: strings that follow the -S command on the command line
 * monitoring: Boolean, whether to run the monitoring script on this suite
 * cylc_version: 7 or 8
+* use_next_cylc: String, if defined will use this string after export
+  CYLC_VERSION=. Intended to test the 'next' version of cylc
 """
 
 import os
@@ -200,7 +202,6 @@ def export_cylc_string(suite, cylc_version):
     """
     Based on the cylc version and the use_next_cylc setting return the version
     string to export
-    Assumes the next cylc version is loaded with 'export CYLC_VERSION=8-next'
     """
 
     if "use_next_cylc" not in suite or not suite["use_next_cylc"]:

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -39,7 +39,7 @@ import yaml
 import argparse
 import subprocess
 
-DEFAULT_CYLC_VERSION = 8
+DEFAULT_CYLC_VERSION = "8"
 DEPENDENCIES = {
     "lfric_apps": [
         "casim",

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -21,7 +21,9 @@ Optional:
 * revisions: heads to use the HoT for sub-repos, set to use the set revisions
 * vars: strings that follow the -S command on the command line
 * monitoring: Boolean, whether to run the monitoring script on this suite
-* cylc_version: 7 or 8
+* cylc_version: Can be any string beginning 7 or 8 that is a valid cylc install
+                at the site, such that `export CYLC_VERSION=<cylc_version>`
+                works.
 """
 
 import os
@@ -206,7 +208,7 @@ def generate_clean_commands(cylc_version, name, log_file):
         f"{PROFILE} ; "
         f"export CYLC_VERSION={cylc_version} ; "
         f"cylc stop '{name}' >/dev/null 2>&1 ; sleep 10 ; "
-        f"{CYLC_DIFFS[cylc_version]['clean']} -y -q {name} "
+        f"{CYLC_DIFFS[int(cylc_version[0])]['clean']} -y -q {name} "
         f">> {log_file} 2>&1\n"
     )
 
@@ -239,7 +241,7 @@ def generate_rose_stem_command(suite, wc_path, cylc_version, name):
     return (
         f"export CYLC_VERSION={cylc_version} ; "
         + f"rose stem --group={suite['groups']} "
-        + f"{CYLC_DIFFS[cylc_version]['name']}{name} "
+        + f"{CYLC_DIFFS[int(cylc_version[0])]['name']}{name} "
         + f"--source={wc_path} "
     )
 
@@ -305,7 +307,7 @@ def generate_main_job(name, suite, log_file, wc_path, cylc_version):
 
     cron_job += f">> {log_file} 2>&1"
 
-    if cylc_version == 8:
+    if int(cylc_version[0]) == 8:
         cron_job += f" ; cylc play {name} >> {log_file} 2>&1"
 
     return cron_job + "\n"
@@ -318,6 +320,7 @@ def generate_cron_job(suite_name, suite, log_file):
     """
 
     cylc_version = suite.get("cylc_version", DEFAULT_CYLC_VERSION)
+    cylc_version = str(cylc_version)
 
     date_str = f"_$({DATE_BASE})"
     name = suite_name + date_str

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# *****************************COPYRIGHT*******************************
+# (C) Crown copyright Met Office. All rights reserved.
+# For further details please refer to the file COPYRIGHT.txt
+# which you should have received as part of this distribution.
+# *****************************COPYRIGHT*******************************
+
 """
 Scan a users (inteded as frzz for nightly testing) cylc-run directory for
 cylc8 suites with uncompleted tasks

--- a/nightly_testing/tests/test_generate_test_suite_cron.py
+++ b/nightly_testing/tests/test_generate_test_suite_cron.py
@@ -226,20 +226,16 @@ def test_populate_cl_variables(suite, expected):
 data_major_cylc_version = [
     (
         "7",
-        7
+        "7"
     ),
     (
         "8",
-        8
+        "8"
     ),
     (
         "8-next",
-        8
+        "8"
     ),
-    (
-        8,
-        8
-    )
 ]
 @pytest.mark.parametrize(
     ("version", "expected"),

--- a/nightly_testing/tests/test_generate_test_suite_cron.py
+++ b/nightly_testing/tests/test_generate_test_suite_cron.py
@@ -99,12 +99,14 @@ def test_generate_cron_timing_str(suite, mode, expected):
 # Test generate_clean_commands
 data_generate_clean_commands = [
     (
+        {},
         7,
         "suite_name",
         "cron_log",
         f"{PROFILE} ; export CYLC_VERSION=7 ; cylc stop 'suite_name' >/dev/null 2>&1 ; sleep 10 ; rose suite-clean -y -q suite_name >> cron_log 2>&1\n"
     ),
     (
+        {},
         8,
         "suite_name",
         "cron_log",
@@ -112,11 +114,11 @@ data_generate_clean_commands = [
     )
 ]
 @pytest.mark.parametrize(
-    ("cylc_version", "name", "log_file", "expected"),
+    ("suite", "cylc_version", "name", "log_file", "expected"),
     [test_data for test_data in data_generate_clean_commands]
 )
-def test_generate_clean_commands(cylc_version, name, log_file, expected):
-    assert generate_clean_commands(cylc_version, name, log_file) == expected
+def test_generate_clean_commands(suite, cylc_version, name, log_file, expected):
+    assert generate_clean_commands(suite, cylc_version, name, log_file) == expected
 
 
 # Test generate_rose_stem_command
@@ -208,3 +210,34 @@ data_populate_cl_variables = [
 )
 def test_populate_cl_variables(suite, expected):
     assert populate_cl_variables(suite) == expected
+
+
+# Test export_cylc_string
+data_export_cylc_string = [
+    (
+        {},
+        7,
+        7,
+    ),
+    (
+        {},
+        8,
+        8,
+    ),
+    (
+        {"use_next_cylc": ""},
+        8,
+        8,
+    ),
+    (
+        {"use_next_cylc": "8-next"},
+        8,
+        "8-next",
+    )
+]
+@pytest.mark.parametrize(
+    ("suite", "cylc_version", "expected"),
+    [test_data for test_data in data_export_cylc_string]
+)
+def test_export_cylc_string(suite, cylc_version, expected):
+    assert export_cylc_string(suite, cylc_version) == expected

--- a/nightly_testing/tests/test_generate_test_suite_cron.py
+++ b/nightly_testing/tests/test_generate_test_suite_cron.py
@@ -99,14 +99,12 @@ def test_generate_cron_timing_str(suite, mode, expected):
 # Test generate_clean_commands
 data_generate_clean_commands = [
     (
-        {},
         7,
         "suite_name",
         "cron_log",
         f"{PROFILE} ; export CYLC_VERSION=7 ; cylc stop 'suite_name' >/dev/null 2>&1 ; sleep 10 ; rose suite-clean -y -q suite_name >> cron_log 2>&1\n"
     ),
     (
-        {},
         8,
         "suite_name",
         "cron_log",
@@ -114,11 +112,11 @@ data_generate_clean_commands = [
     )
 ]
 @pytest.mark.parametrize(
-    ("suite", "cylc_version", "name", "log_file", "expected"),
+    ("cylc_version", "name", "log_file", "expected"),
     [test_data for test_data in data_generate_clean_commands]
 )
-def test_generate_clean_commands(suite, cylc_version, name, log_file, expected):
-    assert generate_clean_commands(suite, cylc_version, name, log_file) == expected
+def test_generate_clean_commands(cylc_version, name, log_file, expected):
+    assert generate_clean_commands(cylc_version, name, log_file) == expected
 
 
 # Test generate_rose_stem_command
@@ -210,34 +208,3 @@ data_populate_cl_variables = [
 )
 def test_populate_cl_variables(suite, expected):
     assert populate_cl_variables(suite) == expected
-
-
-# Test export_cylc_string
-data_export_cylc_string = [
-    (
-        {},
-        7,
-        7,
-    ),
-    (
-        {},
-        8,
-        8,
-    ),
-    (
-        {"use_next_cylc": ""},
-        8,
-        8,
-    ),
-    (
-        {"use_next_cylc": "8-next"},
-        8,
-        "8-next",
-    )
-]
-@pytest.mark.parametrize(
-    ("suite", "cylc_version", "expected"),
-    [test_data for test_data in data_export_cylc_string]
-)
-def test_export_cylc_string(suite, cylc_version, expected):
-    assert export_cylc_string(suite, cylc_version) == expected

--- a/nightly_testing/tests/test_generate_test_suite_cron.py
+++ b/nightly_testing/tests/test_generate_test_suite_cron.py
@@ -98,16 +98,22 @@ def test_generate_cron_timing_str(suite, mode, expected):
 # Test generate_clean_commands
 data_generate_clean_commands = [
     (
-        7,
+        "7",
         "suite_name",
         "cron_log",
         f"{PROFILE} ; export CYLC_VERSION=7 ; cylc stop 'suite_name' >/dev/null 2>&1 ; sleep 10 ; rose suite-clean -y -q suite_name >> cron_log 2>&1\n"
     ),
     (
-        8,
+        "8",
         "suite_name",
         "cron_log",
         f"{PROFILE} ; export CYLC_VERSION=8 ; cylc stop 'suite_name' >/dev/null 2>&1 ; sleep 10 ; cylc clean --timeout=7200 -y -q suite_name >> cron_log 2>&1\n"
+    ),
+    (
+        "8-next",
+        "suite_name",
+        "cron_log",
+        f"{PROFILE} ; export CYLC_VERSION=8-next ; cylc stop 'suite_name' >/dev/null 2>&1 ; sleep 10 ; cylc clean --timeout=7200 -y -q suite_name >> cron_log 2>&1\n"
     )
 ]
 @pytest.mark.parametrize(
@@ -123,16 +129,23 @@ data_generate_rose_stem_command = [
     (
         {"groups": "all"},
         "path/to/wc",
-        7,
+        "7",
         "suite_name",
         "export CYLC_VERSION=7 ; rose stem --group=all --name=suite_name --source=path/to/wc "
     ),
     (
         {"groups": "nightly"},
         "path/to/wc",
-        8,
+        "8",
         "suite_name",
         "export CYLC_VERSION=8 ; rose stem --group=nightly --workflow-name=suite_name --source=path/to/wc "
+    ),
+    (
+        {"groups": "nightly"},
+        "path/to/wc",
+        "8-next",
+        "suite_name",
+        "export CYLC_VERSION=8-next ; rose stem --group=nightly --workflow-name=suite_name --source=path/to/wc "
     )
 ]
 @pytest.mark.parametrize(

--- a/nightly_testing/tests/test_generate_test_suite_cron.py
+++ b/nightly_testing/tests/test_generate_test_suite_cron.py
@@ -220,3 +220,30 @@ data_populate_cl_variables = [
 )
 def test_populate_cl_variables(suite, expected):
     assert populate_cl_variables(suite) == expected
+
+
+# Test major_cylc_version
+data_major_cylc_version = [
+    (
+        "7",
+        7
+    ),
+    (
+        "8",
+        8
+    ),
+    (
+        "8-next",
+        8
+    ),
+    (
+        8,
+        8
+    )
+]
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [test_data for test_data in data_major_cylc_version]
+)
+def test_major_cylc_version(version, expected):
+    assert major_cylc_version(version) == expected


### PR DESCRIPTION
I've had a request from Oliver asking if we're able to do some "next-version" testing of cylc with our rose-stems when it has an initial deploy in the near future. This PR adds that functionality to the nightly testing script. The script has been run with the example yaml file with a suitable example and produces the expected output. Unit tests have been added for the new function.