### PR TITLE
Fix heads copy

### DIFF
--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -74,7 +74,7 @@ def run_command(command):
 
 def join_checkout_commands(repos, dir_wc):
     """
-    Join commands that delete repo then checkout new one
+    Join commands that checkout new repos
     """
 
     command = ""
@@ -87,7 +87,8 @@ def join_checkout_commands(repos, dir_wc):
 def fetch_working_copy_cron():
     """
     Cleanup and then re-checkout working copies for each of the repos used
-    Runs just after midnight ahead of all other tasks
+    Create an lfric_apps heads working copy
+    Runs at 23:30, before all other tasks
     """
 
     command = "# Checkout Working Copies - every day at 23:30 #"

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -109,7 +109,7 @@ def lfric_heads_sed(wc_path):
     wc_path_new = wc_path + "_heads"
     dep_path = os.path.join(wc_path_new, "dependencies.sh")
 
-    rstr = f"cp -r {wc_path} {wc_path_new} ; "
+    rstr = f"cp -rf {wc_path} {wc_path_new} ; "
     rstr += f"sed -i -e 's/^\\(export .*_revision=@\\).*/\\1HEAD/' {dep_path} ; "
     rstr += f"sed -i -e 's/^\\(export .*_rev=\\).*/\\1HEAD/' {dep_path} ; "
     return rstr, wc_path_new

--- a/nightly_testing/tests/test_generate_test_suite_cron.py
+++ b/nightly_testing/tests/test_generate_test_suite_cron.py
@@ -28,7 +28,7 @@ def test_join_checkout_commands(inlist, scratch, expected):
 data_lfric_heads_sed = [
     (
         "path/to/wc",
-        "cp -r path/to/wc path/to/wc_heads ; sed -i -e 's/^\\(export .*_revision=@\\).*/\\1HEAD/' path/to/wc_heads/dependencies.sh ; sed -i -e 's/^\\(export .*_rev=\\).*/\\1HEAD/' path/to/wc_heads/dependencies.sh ; ",
+        "cp -rf path/to/wc path/to/wc_heads ; sed -i -e 's/^\\(export .*_revision=@\\).*/\\1HEAD/' path/to/wc_heads/dependencies.sh ; sed -i -e 's/^\\(export .*_rev=\\).*/\\1HEAD/' path/to/wc_heads/dependencies.sh ; ",
         "path/to/wc_heads"
     )
 ]

--- a/nightly_testing/tests/test_generate_test_suite_cron.py
+++ b/nightly_testing/tests/test_generate_test_suite_cron.py
@@ -8,12 +8,12 @@ data_join_checkout_commands = [
     (
         ["um"],
         "scratch/dir/",
-        "rm -rf scratch/dir/wc_um ; fcm co -q --force fcm:um.xm_tr@HEAD scratch/dir/wc_um ; "
+        "fcm co -q --force fcm:um.xm_tr@HEAD scratch/dir/wc_um ; "
     ),
     (
         ["um", "lfric"],
         "scratch/dir",
-        "rm -rf scratch/dir/wc_um ; fcm co -q --force fcm:um.xm_tr@HEAD scratch/dir/wc_um ; rm -rf scratch/dir/wc_lfric ; fcm co -q --force fcm:lfric.xm_tr@HEAD scratch/dir/wc_lfric ; "
+        "fcm co -q --force fcm:um.xm_tr@HEAD scratch/dir/wc_um ; fcm co -q --force fcm:lfric.xm_tr@HEAD scratch/dir/wc_lfric ; "
     )
 ]
 @pytest.mark.parametrize(
@@ -29,15 +29,14 @@ data_lfric_heads_sed = [
     (
         "path/to/wc",
         "cp -rf path/to/wc path/to/wc_heads ; sed -i -e 's/^\\(export .*_revision=@\\).*/\\1HEAD/' path/to/wc_heads/dependencies.sh ; sed -i -e 's/^\\(export .*_rev=\\).*/\\1HEAD/' path/to/wc_heads/dependencies.sh ; ",
-        "path/to/wc_heads"
     )
 ]
 @pytest.mark.parametrize(
-    ("wc_path", "expected", "new_wc"),
+    ("wc_path", "expected"),
     [test_data for test_data in data_lfric_heads_sed]
 )
-def test_lfric_heads_sed(wc_path, expected, new_wc):
-    assert lfric_heads_sed(wc_path) == (expected, new_wc)
+def test_lfric_heads_sed(wc_path, expected):
+    assert lfric_heads_sed(wc_path) == (expected)
 
 
 # Test generate_cron_timing_str


### PR DESCRIPTION
The copy command moving the lfric_apps working copy to a new copy for heads has been failing. This adds a -f flag to stop that and also rearranges where this copy occurs to only do it once per night.