### PR TITLE
modify equality type

### DIFF
--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -323,7 +323,7 @@ def generate_main_job(name, suite, log_file, wc_path, cylc_version):
 
     cron_job += f">> {log_file} 2>&1"
 
-    if major_cylc_version(cylc_version) == 8:
+    if major_cylc_version(cylc_version) == "8":
         cron_job += f" ; cylc play {name} >> {log_file} 2>&1"
 
     return cron_job + "\n"


### PR DESCRIPTION
In the last change the type returned by get_major_cylc_version was changed during the review process. This equality was missed so the cylc play command for cylc8 suites didn't happen. Have double checked the output of the script now which contains the cylc play commands.