### PR TITLE
Fix cylc8 source URL

### DIFF
--- a/suite_report.py
+++ b/suite_report.py
@@ -804,9 +804,11 @@ class SuiteReport(object):
             start_url += f"/{splitter}/"
             end_url = end_url.split("/")
             if splitter == "branches":
+                # For branches, format is "/branches/[dev|test]/[branch-name]"
                 end_url = f"{end_url[0]}/{end_url[1]}/{end_url[2]}"
             else:
-                end_url = end_url[0]
+                # For trunk, format is just "/trunk/"
+                end_url = ""
             projects[project]["repo loc"] = start_url + end_url + ending
 
         for item in vcs_data["status"]:

--- a/suite_report.py
+++ b/suite_report.py
@@ -804,7 +804,7 @@ class SuiteReport(object):
             start_url += f"/{splitter}/"
             end_url = end_url.split("/")
             if splitter == "branches":
-                # For branches, format is "/branches/[dev|test]/[branch-name]"
+                # For branches, format is "/[dev|test]/<username>/<branch-name>"
                 end_url = f"{end_url[0]}/{end_url[1]}/{end_url[2]}"
             else:
                 # For trunk, format is just "/trunk/"

--- a/suite_report.py
+++ b/suite_report.py
@@ -791,7 +791,23 @@ class SuiteReport(object):
                 project = project[len(prefix_svn) :]
             project = re.split("[/.]", project)[0].upper()
             projects[project] = {}
-            projects[project]["repo loc"] = vcs_data["url"] + ending
+
+            # Use the version control url as the project source
+            # This url isn't necessarily to top of the working copy so split
+            # the url around "branches" or "trunk" to ensure the correct url
+            url = vcs_data["url"]
+            if "branches" in url:
+                splitter = "branches"
+            else:
+                splitter = "trunk"
+            start_url, end_url = url.split(f"/{splitter}/", 1)
+            start_url += f"/{splitter}/"
+            end_url = end_url.split("/")
+            if splitter == "branches":
+                end_url = f"{end_url[0]}/{end_url[1]}/{end_url[2]}"
+            else:
+                end_url = end_url[0]
+            projects[project]["repo loc"] = start_url + end_url + ending
 
         for item in vcs_data["status"]:
             if not item.startswith("?") and len(item) > 0:


### PR DESCRIPTION
In cylc8 suite_report determines the source URL from the version control file. This URL isn't guaranteed to be the top of a "working copy", so modify suite_report to parse this url such that it is the case.