### PR TITLE
UMPD3 checker: Check external repositories when they are modified by a branch.

### DIFF
--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -351,11 +351,11 @@ if ( $trunkmode == 0 ) {
 my @extracts = ();
 
 if ( $trunkmode == 0 ) {
-     if $suite_mode {
+     if ($suite_mode) {
         # enable trunkmode for sepecific repositories if the environment does not match rose-stem/rose-suite.conf
 
         my $ss_env = $ENV{SCRIPT_SOURCE};
-        my @suite_conf = cat_file($ss_env+"/rose-stem/rose-suite.conf");
+        my @suite_conf = cat_file($ss_env + "/rose-stem/rose-suite.conf");
         my @host_sources = grep /^HOST_SOURCE_.*=/, @suite_conf;
         
         print "Detected HOST_SOURCE variables:\n";

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -355,7 +355,7 @@ if ( $trunkmode == 0 ) {
         # enable trunkmode for sepecific repositories if the environment does not match rose-stem/rose-suite.conf
 
         my $ss_env = $ENV{SCRIPT_SOURCE};
-        my @suite_conf = cat_file($ss_env . "/rose-stem/rose-suite.conf");
+        my @suite_conf = cat_file($ss_env . "/um/rose-stem/rose-suite.conf");
         my @host_sources = grep /^HOST_SOURCE_.*=/, @suite_conf;
         
         print "Detected HOST_SOURCE variables:\n";

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -351,6 +351,7 @@ if ( $trunkmode == 0 ) {
 # The @external_checks array contains the names of all the non-UM repositories
 # extracted by the UM which should also be checked.
 my @external_checks = ( "shumlib", "meta", "ukca" );
+my %filepath_mapping = ( 'meta' => 'um_meta' );
 my @extracts = ();
 
 if ( $trunkmode == 0 ) {
@@ -367,11 +368,15 @@ if ( $trunkmode == 0 ) {
         foreach (@external_checks)
         {
             my $repo = $_;
+            my $o_repo = $repo;
+            if (exists $filepath_mapping{$repo}) {
+                $repo = $filepath_mapping{$repo};
+            }
             my $host_var_name = "HOST_SOURCE_" . uc($repo);
             my $env_var_res = $ENV{$host_var_name};
             if (! grep /^$host_var_name=(\"|\')$env_var_res(\"|\')/, @host_sources ) {
                print $host_var_name . " modified in environment. Running full check on this repository\n";
-               push @extracts, $repo;
+               push @extracts, $o_repo;
             } 
         }
 
@@ -385,10 +390,14 @@ if ( $trunkmode == 0 ) {
         foreach (@external_checks)
         {
             my $repo = $_;
+            my $o_repo = $repo;
+            if (exists $filepath_mapping{$repo}) {
+                $repo = $filepath_mapping{$repo};
+            }
             my $host_var_name = "HOST_SOURCE_" . uc($repo);
             if ( grep /^$host_var_name=/, @added_lines ) {
                print $host_var_name . " modified in rose-suite.conf. Running full check on this repository\n";
-               push @extracts, $repo;
+               push @extracts, $o_repo;
             } 
         }
      }
@@ -399,6 +408,7 @@ if ( $trunkmode == 0 ) {
      # If we capturede any changes, enable trunk-mode for those repositories.
      if (scalar(@extracts) > 0) {
          $trunkmode = 1;
+         $error_trunk = 1;
          unshift @extracts, "";
      }     
 }

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -369,8 +369,8 @@ if ( $trunkmode == 0 ) {
             my $repo = $_;
             my $host_var_name = "HOST_SOURCE_" . uc($repo);
             my $env_var_res = $ENV{$host_var_name};
-            if (! grep /^$host_var_name=$env_var_res/, @host_sources ) {
-               print $host_var_name . " modified. Running full check on this repository\n";
+            if (! grep /^$host_var_name=(\"|\')$env_var_res(\"|\')/, @host_sources ) {
+               print $host_var_name . " modified in environment. Running full check on this repository\n";
                push @extracts, $repo;
             } 
         }
@@ -379,7 +379,18 @@ if ( $trunkmode == 0 ) {
 
      # enable trunkmode for sepecific repositories if rose-stem/rose-suite.conf is modified
      if (exists $additions{"rose-stem/rose-suite.conf"}) {
-         print "rose-stem/rose-suite.conf modified: checking for external repository updates\n";
+        print "rose-stem/rose-suite.conf modified: checking for external repository updates\n";
+        my $added_lines_ref = $additions{"rose-stem/rose-suite.conf"};
+        my @added_lines     = @$added_lines_ref;
+        foreach (@external_checks)
+        {
+            my $repo = $_;
+            my $host_var_name = "HOST_SOURCE_" . uc($repo);
+            if ( grep /^$host_var_name=/, @added_lines ) {
+               print $host_var_name . " modified in rose-suite.conf. Running full check on this repository\n";
+               push @extracts, $repo;
+            } 
+        }
      }
 
      # remove any duplicates

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -364,13 +364,14 @@ if ( $trunkmode == 0 ) {
         print "Detected HOST_SOURCE variables:\n";
         print join( "", @host_sources );
 
-        foreach (@host_sources)
+        foreach (@external_checks)
         {
-            my $host_var_name = "HOST_SOURCE_" . uc($_);
+            my $repo = $_;
+            my $host_var_name = "HOST_SOURCE_" . uc($repo);
             my $env_var_res = $ENV{$host_var_name};
             if (! grep /^$host_var_name=$env_var_res/, @host_sources ) {
                print $host_var_name . " modified. Running full check on this repository\n";
-               push @extracts, $_;
+               push @extracts, $repo;
             } 
         }
 

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -357,7 +357,7 @@ my @extracts = ();
 if ( $trunkmode == 0 ) {
     if ($suite_mode) {
 
-        # enable trunkmode for sepecific repositories if the environment does
+        # enable trunkmode for specific repositories if the environment does
         # not match rose-stem/rose-suite.conf
 
         my $ss_env     = $ENV{SCRIPT_SOURCE};

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -348,6 +348,9 @@ if ( $trunkmode == 0 ) {
 
 }
 
+# The @external_checks array contains the names of all the non-UM repositories
+# extracted by the UM which should also be checked.
+my @external_checks = ( "shumlib", "meta", "ukca" );
 my @extracts = ();
 
 if ( $trunkmode == 0 ) {
@@ -359,7 +362,17 @@ if ( $trunkmode == 0 ) {
         my @host_sources = grep /^HOST_SOURCE_.*=/, @suite_conf;
         
         print "Detected HOST_SOURCE variables:\n";
-        print join( "\n", @host_sources );
+        print join( "", @host_sources );
+
+        foreach (@host_sources)
+        {
+            my $host_var_name = "HOST_SOURCE_" . uc($_);
+            my $env_var_res = $ENV{$host_var_name};
+            if (! grep /^$host_var_name=$env_var_res/, @host_sources ) {
+               print $host_var_name . " modified. Running full check on this repository\n";
+               push @extracts, $_;
+            } 
+        }
 
      }
 
@@ -368,15 +381,18 @@ if ( $trunkmode == 0 ) {
          print "rose-stem/rose-suite.conf modified: checking for external repository updates\n";
      }
 
+     # remove any duplicates
      @extracts = keys {map {$_ => 1} @extracts};
 
+     # If we capturede any changes, enable trunk-mode for those repositories.
      if (scalar(@extracts) > 0) {
          $trunkmode = 1;
          unshift @extracts, "";
      }     
 }
 else {
-    @extracts = ( "", "um", "shumlib", "meta", "ukca" );
+    @extracts = ( "", "um" );
+    push @extracts, @external_checks;
 }
 
 if ( $trunkmode == 1 ) {

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -387,7 +387,7 @@ if ( $trunkmode == 0 ) {
 
     }
 
-    # enable trunkmode for sepecific repositories if rose-stem/rose-suite.conf
+    # enable trunkmode for specific repositories if rose-stem/rose-suite.conf
     # is modified
     if ( exists $additions{"rose-stem/rose-suite.conf"} ) {
         print "rose-stem/rose-suite.conf modified:"

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -348,13 +348,32 @@ if ( $trunkmode == 0 ) {
 
 }
 
-my @extracts = ( "" );
+my @extracts = ();
 
 if ( $trunkmode == 0 ) {
-    # enable trunkmode for sepecific repositories if rose-stem/rose-suite.conf is modified
-    if (exists $additions{"ose-stem/rose-suite.conf"}) {
-        print "rose-stem/rose-suite.conf modified: checking for external repository updates\n";
-    }
+     if $suite_mode {
+        # enable trunkmode for sepecific repositories if the environment does not match rose-stem/rose-suite.conf
+
+        my $ss_env = $ENV{SCRIPT_SOURCE};
+        my @suite_conf = cat_file($ss_env+/"rose-stem/rose-suite.conf");
+        my @host_sources = grep /^HOST_SOURCE_.*=/, @suite_conf;;
+        
+        print "Detected HOST_SOURCE variables:\n";
+        print join( "\n", @host_sources );
+
+     }
+
+     # enable trunkmode for sepecific repositories if rose-stem/rose-suite.conf is modified
+     if (exists $additions{"rose-stem/rose-suite.conf"}) {
+         print "rose-stem/rose-suite.conf modified: checking for external repository updates\n";
+     }
+
+     @extracts = keys {map {$_ => 1} @extracts};
+
+     if scalar(@extracts) > 0 {
+         $trunkmode = 1;
+         unshift @extracts, "";
+     }     
 }
 else {
     @extracts = ( "", "um", "shumlib", "meta", "ukca" );

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -370,7 +370,7 @@ if ( $trunkmode == 0 ) {
 
      @extracts = keys {map {$_ => 1} @extracts};
 
-     if scalar(@extracts) > 0 {
+     if (scalar(@extracts) > 0) {
          $trunkmode = 1;
          unshift @extracts, "";
      }     

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -355,62 +355,70 @@ my %filepath_mapping = ( 'meta' => 'um_meta' );
 my @extracts = ();
 
 if ( $trunkmode == 0 ) {
-     if ($suite_mode) {
-        # enable trunkmode for sepecific repositories if the environment does not match rose-stem/rose-suite.conf
+    if ($suite_mode) {
 
-        my $ss_env = $ENV{SCRIPT_SOURCE};
-        my @suite_conf = cat_file($ss_env . "/um/rose-stem/rose-suite.conf");
+        # enable trunkmode for sepecific repositories if the environment does
+        # not match rose-stem/rose-suite.conf
+
+        my $ss_env     = $ENV{SCRIPT_SOURCE};
+        my @suite_conf = cat_file( $ss_env . "/um/rose-stem/rose-suite.conf" );
         my @host_sources = grep /^HOST_SOURCE_.*=/, @suite_conf;
-        
+
         print "Detected HOST_SOURCE variables:\n";
         print join( "", @host_sources );
 
-        foreach (@external_checks)
-        {
-            my $repo = $_;
+        foreach (@external_checks) {
+            my $repo   = $_;
             my $o_repo = $repo;
-            if (exists $filepath_mapping{$repo}) {
+            if ( exists $filepath_mapping{$repo} ) {
                 $repo = $filepath_mapping{$repo};
             }
             my $host_var_name = "HOST_SOURCE_" . uc($repo);
-            my $env_var_res = $ENV{$host_var_name};
-            if (! grep /^$host_var_name=(\"|\')$env_var_res(\"|\')/, @host_sources ) {
-               print $host_var_name . " modified in environment. Running full check on this repository\n";
-               push @extracts, $o_repo;
-            } 
+            my $env_var_res   = $ENV{$host_var_name};
+            if ( !grep /^$host_var_name=(\"|\')$env_var_res(\"|\')/,
+                @host_sources )
+            {
+                print $host_var_name
+                  . " modified in environment."
+                  . " Running full check on this repository\n";
+                push @extracts, $o_repo;
+            }
         }
 
-     }
+    }
 
-     # enable trunkmode for sepecific repositories if rose-stem/rose-suite.conf is modified
-     if (exists $additions{"rose-stem/rose-suite.conf"}) {
-        print "rose-stem/rose-suite.conf modified: checking for external repository updates\n";
+    # enable trunkmode for sepecific repositories if rose-stem/rose-suite.conf
+    # is modified
+    if ( exists $additions{"rose-stem/rose-suite.conf"} ) {
+        print "rose-stem/rose-suite.conf modified:"
+          . " checking for external repository updates\n";
         my $added_lines_ref = $additions{"rose-stem/rose-suite.conf"};
         my @added_lines     = @$added_lines_ref;
-        foreach (@external_checks)
-        {
-            my $repo = $_;
+        foreach (@external_checks) {
+            my $repo   = $_;
             my $o_repo = $repo;
-            if (exists $filepath_mapping{$repo}) {
+            if ( exists $filepath_mapping{$repo} ) {
                 $repo = $filepath_mapping{$repo};
             }
             my $host_var_name = "HOST_SOURCE_" . uc($repo);
             if ( grep /^$host_var_name=/, @added_lines ) {
-               print $host_var_name . " modified in rose-suite.conf. Running full check on this repository\n";
-               push @extracts, $o_repo;
-            } 
+                print $host_var_name
+                  . " modified in rose-suite.conf."
+                  . " Running full check on this repository\n";
+                push @extracts, $o_repo;
+            }
         }
-     }
+    }
 
-     # remove any duplicates
-     @extracts = keys {map {$_ => 1} @extracts};
+    # remove any duplicates
+    @extracts = keys { map { $_ => 1 } @extracts };
 
-     # If we capturede any changes, enable trunk-mode for those repositories.
-     if (scalar(@extracts) > 0) {
-         $trunkmode = 1;
-         $error_trunk = 1;
-         unshift @extracts, "";
-     }     
+    # If we capturede any changes, enable trunk-mode for those repositories.
+    if ( scalar(@extracts) > 0 ) {
+        $trunkmode   = 1;
+        $error_trunk = 1;
+        unshift @extracts, "";
+    }
 }
 else {
     @extracts = ( "", "um" );

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -347,7 +347,20 @@ if ( $trunkmode == 0 ) {
     }
 
 }
+
+my @extracts = ( "" );
+
+if ( $trunkmode == 0 ) {
+    # enable trunkmode for sepecific repositories if rose-stem/rose-suite.conf is modified
+    if (exists $additions{"ose-stem/rose-suite.conf"}) {
+        print "rose-stem/rose-suite.conf modified: checking for external repository updates\n";
+    }
+}
 else {
+    @extracts = ( "", "um", "shumlib", "meta", "ukca" );
+}
+
+if ( $trunkmode == 1 ) {
 
     #trunk mode: cat all the source files to %additions
 
@@ -358,8 +371,6 @@ else {
 
         # If we are in suite mode, we need to generate the ls from the extracted
         # sources, not from FCM.
-
-        my @extracts = ( "", "um", "shumlib", "meta", "ukca" );
 
         my $ss_env = $ENV{SCRIPT_SOURCE};
         my $extracts_path = join( " $ss_env/", @extracts );

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -413,7 +413,7 @@ if ( $trunkmode == 0 ) {
     # remove any duplicates
     @extracts = keys { map { $_ => 1 } @extracts };
 
-    # If we capturede any changes, enable trunk-mode for those repositories.
+    # If we captured any changes, enable trunk-mode for those repositories.
     if ( scalar(@extracts) > 0 ) {
         $trunkmode   = 1;
         $error_trunk = 1;

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -355,8 +355,8 @@ if ( $trunkmode == 0 ) {
         # enable trunkmode for sepecific repositories if the environment does not match rose-stem/rose-suite.conf
 
         my $ss_env = $ENV{SCRIPT_SOURCE};
-        my @suite_conf = cat_file($ss_env+/"rose-stem/rose-suite.conf");
-        my @host_sources = grep /^HOST_SOURCE_.*=/, @suite_conf;;
+        my @suite_conf = cat_file($ss_env+"/rose-stem/rose-suite.conf");
+        my @host_sources = grep /^HOST_SOURCE_.*=/, @suite_conf;
         
         print "Detected HOST_SOURCE variables:\n";
         print join( "\n", @host_sources );

--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -355,7 +355,7 @@ if ( $trunkmode == 0 ) {
         # enable trunkmode for sepecific repositories if the environment does not match rose-stem/rose-suite.conf
 
         my $ss_env = $ENV{SCRIPT_SOURCE};
-        my @suite_conf = cat_file($ss_env + "/rose-stem/rose-suite.conf");
+        my @suite_conf = cat_file($ss_env . "/rose-stem/rose-suite.conf");
         my @host_sources = grep /^HOST_SOURCE_.*=/, @suite_conf;
         
         print "Detected HOST_SOURCE variables:\n";


### PR DESCRIPTION
Currently, UM dependencies are checked by the UMDP3 checker on the trunk.

However, in a branch, the branch diff is used rather than the source files themselves. (This means the script only checks things that are changed by a branch, not the entire source tree.) 

This in turn means changes from the other dependencies are not checked until _after_ they are on trunk in a linked ticket. (This is because the branch diff contains only the changes to the sources, not the code changes themselves - which exist in a different repository.)

This pull request modifies the script to ensure dependencies are checked with the branch, when the script identifies that either the `rose-suite.conf` file, or the `HOST_SOURCE` environment variables have been modified. In that case, it inspects the full source of the external repository, as it would do on trunk.