### PR TITLE
Remove retired perl feature from UMDP3 checker

### DIFF
--- a/script_umdp3_checker/bin/umdp3_check.pl
+++ b/script_umdp3_checker/bin/umdp3_check.pl
@@ -417,7 +417,8 @@ if ( $trunkmode == 0 ) {
     }
 
     # remove any duplicates
-    @extracts = keys { map { $_ => 1 } @extracts };
+    my %unique_extracts = map { $_ => 1 } @extracts;
+    @extracts = keys %unique_extracts;
 
     # If we captured any changes, enable trunk-mode for those repositories.
     if ( scalar(@extracts) > 0 ) {


### PR DESCRIPTION
The UMDP3 checker uses a perl feature which assumes that keys() can be called in a scalar context, based on an experimental feature introduced in v5.14 which has now been withdrawn.

This changes the code to use a temporary hash to make the context of the call explict.  This allows the keys() function to be used to generate a list of unique extracted names.