### PR TITLE
add core to nightly script

### DIFF
--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -51,6 +51,7 @@ DEPENDENCIES = {
         "um",
     ],
     "um": ["casim", "jules", "mule", "shumlib", "socrates", "ukca"],
+    "lfric": [],
     "jules": [],
     "ukca": [],
 }


### PR DESCRIPTION
We've been asked to run lfric core test suites from the umtest nightly setup. This requires a small edit to the nightly testing script to add lfric as a repo.