### PR TITLE
Central meta changes

### DIFF
--- a/lfric_macros/apply_macros.py
+++ b/lfric_macros/apply_macros.py
@@ -234,6 +234,7 @@ class ApplyMacros:
         # copy in LFRic, rather than using the Jules version. The LFRic build
         # system needs modifying to enable this
         # self.jules_source = self.get_dependency_paths(jules, "jules")
+        self.central_rose_meta = False
         self.set_rose_meta_path()
         if version is None:
             self.version = re.search(r".*vn(\d+\.\d+)(_.*)?", tag).group(1)
@@ -246,7 +247,6 @@ class ApplyMacros:
         self.sections_with_macro = []
         self.python_imports = set()
         self.upgraded_core = False
-        self.central_rose_meta = False
 
     def set_rose_meta_path(self):
         """
@@ -693,7 +693,12 @@ class ApplyMacros:
             - A list of meta imports in the correct order
         """
 
-        app_name = os.path.basename(app)
+        # If using central metadata, use the basename, otherwise the full path
+        if self.central_rose_meta:
+            app_name = os.path.basename(app)
+        else:
+            app_name = app
+
         import_list = [app_name]
 
         try:

--- a/lfric_macros/apply_macros.py
+++ b/lfric_macros/apply_macros.py
@@ -245,7 +245,13 @@ class ApplyMacros:
         When Jules Shared from Jules is enabled, self.jules_source will need
         adding here
         """
-        rose_meta_path = f"{self.root_path}:{self.core_source}"
+        if os.path.isdir(os.path.join(self.root_path, "rose-meta")):
+            rose_meta_path = (
+                f"{os.path.join(self.root_path, 'rose-meta')}:"
+                f"{os.path.join(self.core_source, 'rose-meta')}"
+            )
+        else:
+            rose_meta_path = f"{self.root_path}:{self.core_source}"
         os.environ["ROSE_META_PATH"] = rose_meta_path
 
     def parse_application_section(self, meta_dir):
@@ -560,20 +566,20 @@ class ApplyMacros:
               not found
         """
 
-        core_imp = os.path.join(self.core_source, imp)
+        core_imp = os.path.join(self.core_source, "rose-meta", imp)
         if os.path.exists(core_imp) or os.path.exists(
             os.path.dirname(core_imp)
         ):
             return core_imp
 
         # Reinstate when using Jules Shared from Jules
-        # jules_imp = os.path.join(self.jules_source, imp)
+        # jules_imp = os.path.join(self.jules_source, "rose-meta", imp)
         # if os.path.exists(jules_imp) or os.path.exists(
         #     os.path.dirname(jules_imp)
         # ):
         #     return jules_imp
 
-        apps_imp = os.path.join(self.root_path, imp)
+        apps_imp = os.path.join(self.root_path, "rose-meta", imp)
         if os.path.exists(apps_imp) or os.path.exists(
             os.path.dirname(apps_imp)
         ):

--- a/lfric_macros/apply_macros.py
+++ b/lfric_macros/apply_macros.py
@@ -680,7 +680,9 @@ class ApplyMacros:
             - A list of meta imports in the correct order
         """
 
-        import_list = [app]
+        app_name = os.path.basename(app)
+        import_list = [app_name]
+
         try:
             imports = self.parsed_macros[app]["imports"]
         except KeyError:
@@ -764,8 +766,8 @@ class ApplyMacros:
         """
 
         # Get list of versions files to check - in both core and apps
-        self.find_meta_dirs(self.root_path)
-        self.find_meta_dirs(self.core_source)
+        self.find_meta_dirs(os.path.join(self.root_path, "rose-meta"))
+        self.find_meta_dirs(os.path.join(self.core_source, "rose-meta"))
 
         for meta_dir in self.meta_dirs:
             print(
@@ -809,6 +811,7 @@ class ApplyMacros:
         # added macro or import metadata with the new macro
         for meta_dir in self.meta_dirs:
             import_order = self.determine_import_order(meta_dir)
+            print(import_order)
             full_command = self.combine_macros(import_order)
             # If there are commands to write out, do so and record this
             # application as having the macro

--- a/lfric_macros/apply_macros.py
+++ b/lfric_macros/apply_macros.py
@@ -130,7 +130,6 @@ def split_macros(parsed_versions):
     macros = []
     macro = ""
     in_macro = False
-    in_comment = False
     for line in parsed_versions:
         if line.startswith("class vn") and not line.startswith(
             "class vnXX_txxx"

--- a/lfric_macros/apply_macros.py
+++ b/lfric_macros/apply_macros.py
@@ -236,6 +236,7 @@ class ApplyMacros:
         self.sections_with_macro = []
         self.python_imports = set()
         self.upgraded_core = False
+        self.central_rose_meta = False
 
     def set_rose_meta_path(self):
         """
@@ -246,10 +247,12 @@ class ApplyMacros:
         adding here
         """
         if os.path.isdir(os.path.join(self.root_path, "rose-meta")):
+            # For backwards compatibility with central rose-meta imports
             rose_meta_path = (
                 f"{os.path.join(self.root_path, 'rose-meta')}:"
                 f"{os.path.join(self.core_source, 'rose-meta')}"
             )
+            self.central_rose_meta = True
         else:
             rose_meta_path = f"{self.root_path}:{self.core_source}"
         os.environ["ROSE_META_PATH"] = rose_meta_path
@@ -565,15 +568,16 @@ class ApplyMacros:
             - the import statement containing the full path - raises an error if
               not found
         """
-        # Reinstate when using Jules Shared from Jules
-        # jules_imp = os.path.join(self.jules_source, "rose-meta", imp)
-        # if os.path.exists(jules_imp) or os.path.exists(
-        #     os.path.dirname(jules_imp)
-        # ):
-        #     return jules_imp
 
-        core_imp = os.path.join(self.core_source, "rose-meta", imp)
-        apps_imp = os.path.join(self.root_path, "rose-meta", imp)
+        # TODO: Reinstate Jules checks when using Jules Metadata from Jules
+
+        # For backwards compatibility with central rose-meta imports
+        if self.central_rose_meta:
+            core_imp = os.path.join(self.core_source, "rose-meta", imp)
+            apps_imp = os.path.join(self.root_path, "rose-meta", imp)
+        else:
+            core_imp = os.path.join(self.core_source, imp)
+            apps_imp = os.path.join(self.root_path, imp)
 
         if os.path.exists(core_imp):
             return core_imp
@@ -766,8 +770,13 @@ class ApplyMacros:
         """
 
         # Get list of versions files to check - in both core and apps
-        self.find_meta_dirs(os.path.join(self.root_path, "rose-meta"))
-        self.find_meta_dirs(os.path.join(self.core_source, "rose-meta"))
+        # Duplicated for backwards compatibility with central rose-meta imports
+        if self.central_rose_meta:
+            self.find_meta_dirs(os.path.join(self.root_path, "rose-meta"))
+            self.find_meta_dirs(os.path.join(self.core_source, "rose-meta"))
+        else:
+            self.find_meta_dirs(self.root_path)
+            self.find_meta_dirs(self.core_source)
 
         for meta_dir in self.meta_dirs:
             print(

--- a/lfric_macros/apply_macros.py
+++ b/lfric_macros/apply_macros.py
@@ -774,7 +774,7 @@ class ApplyMacros:
 
     def preprocess_macros(self):
         """
-        Overraching function to pre-process added macros
+        Overarching function to pre-process added macros
         Run before running any rose macro upgrade commands"
         Search through versions.py files for macros with the correct after-tag
         Save info and then delete the macro when found


### PR DESCRIPTION
Linked with [LFRic_Apps:#544](https://code.metoffice.gov.uk/trac/lfric_apps/ticket/544).

Changes required to the apply_macros script once metadata import paths work from a toplevel rose-meta directory. This PR will keep backwards compatibility with previous import commands.

This needs to be committed before [LFRic_Apps:#544](https://code.metoffice.gov.uk/trac/lfric_apps/ticket/544)