### PR TITLE
small changes to nightly testing scripts

### DIFF
--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -71,8 +71,6 @@ UMDIR = os.environ["UMDIR"]
 PROFILE = ". /etc/profile"
 DATE_BASE = "date +\\%Y-\\%m-\\%d"
 MONITORING_TIME = "00 06"
-CYLC_INSTALL = "~metomi/apps"
-
 
 def run_command(command):
     """
@@ -392,6 +390,13 @@ def parse_cl_args():
         help="The file any stdout or stderr will be piped to.",
     )
     parser.add_argument(
+        "-p",
+        "--cylc_path",
+        default="~metomi",
+        help="The location of the cylc installation required for testing `next-cylc`"
+        "configs."
+    )
+    parser.add_argument(
         "--install",
         action="store_true",
         help="If True, will install the generated crontab.",
@@ -399,6 +404,8 @@ def parse_cl_args():
     args = parser.parse_args()
     args.cron_file = os.path.expanduser(args.cron_file)
     args.cron_log = os.path.expanduser(args.cron_log)
+    global CYLC_INSTALL
+    CYLC_INSTALL = args.cylc_path
     return args
 
 

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -91,6 +91,8 @@ def restart_suite(suite):
     """
     print(f"Restarting {suite}")
     play_command = f"cylc play -q {suite}"
+    if "next-cylc" in suite:
+        play_command = f"export CYLC_VERSION=8-next ; {play_command}"
     _ = run_command(play_command)
 
 
@@ -103,6 +105,8 @@ def retrigger_suite(suite, tasks):
     for i, task in enumerate(tasks):
         print(f"\rTask {i+1}/{ntasks}", end="", flush=True)
         failed_command = f"cylc trigger {suite}//*/{task[0]}"
+        if "next-cylc" in suite:
+            failed_command = f"export CYLC_VERSION=8-next ; {failed_command}"
         _ = run_command(failed_command)
     print()
 
@@ -185,9 +189,12 @@ if __name__ == "__main__":
     # Restart failed suites
     run_all = ask_yn("Do you want to restart all failed suites")
     restarted_suites = []
+    to_restart = []
     for suite in failed_suites:
         if not run_all and not ask_yn(f"Do you want to restart {suite}"):
             continue
+        to_restart.append(suite)
+    for suite in to_restart:
         restart_suite(suite)
         restarted_suites.append(suite)
 


### PR DESCRIPTION
This makes a couple of minor improvements to the nightly testing scripts:

* Removes any sources left in the lfric_apps dependencies.sh file when doing Heads testing. This means that when the dependencies file update is missed at commit, there will still be valid testing the next night.
* cylc-next testing is only launched if there is a new version of cylc to test. This tests the symlink `cylc-8` and `cylc-next` symlinks and only launches testing if they are not the same.
* Relaunches `cylc-next` tests with the correct environment.