### PR TITLE
Fix macro test old spice

### DIFF
--- a/lfric_macros/check_macro_chains.py
+++ b/lfric_macros/check_macro_chains.py
@@ -95,7 +95,7 @@ def compare_tags(before, after, path, errors):
             "after tag.\nThere should be 2 of these - the beginning of the "
             "chain and the end of the chain.\nThis is likely a typo in the tags in "
             "the versions.py file. The identified tags were:\n"
-            f"{'\n'.join(x for x in single_tags)}"
+            # f"{'\n'.join(x for x in single_tags)}"
         )
 
 

--- a/lfric_macros/check_macro_chains.py
+++ b/lfric_macros/check_macro_chains.py
@@ -95,8 +95,7 @@ def compare_tags(before, after, path, errors):
             "after tag.\nThere should be 2 of these - the beginning of the "
             "chain and the end of the chain.\nThis is likely a typo in the tags in "
             "the versions.py file. The identified tags were:\n"
-            # f"{'\n'.join(x for x in single_tags)}"
-        )
+        ) + "\n".join(x for x in single_tags)
 
 
 def main():


### PR DESCRIPTION
The test added yesterday fails on old spice with `SyntaxError: f-string expression part cannot include a backslash`, presumably because it's using an older version of python. I've modified the offending bit of code and checked it works on old spice.