### PR TITLE
fix for next-cylc testing

### DIFF
--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -336,7 +336,7 @@ def generate_main_job(name, suite, log_file, wc_path, cylc_version):
         next_link = os.path.join(CYLC_INSTALL, "cylc-8-next")
         def_link = os.path.join(CYLC_INSTALL, "cylc-8")
         cron_job += (
-            f'[ "$(readlink -- "{next_link}")" != "$(readlink -- "{def_link}")" ] '
+            f'[ "$(readlink -- {next_link})" != "$(readlink -- {def_link})" ] '
             f"&& ({job_command})"
         )
     else:
@@ -394,7 +394,7 @@ def parse_cl_args():
     parser.add_argument(
         "-p",
         "--cylc_path",
-        default="~metomi",
+        default="~/apps",
         help="The location of the cylc installation required for testing `next-cylc`"
         "configs.",
     )

--- a/nightly_testing/generate_test_suite_cron.py
+++ b/nightly_testing/generate_test_suite_cron.py
@@ -394,7 +394,7 @@ def parse_cl_args():
     parser.add_argument(
         "-p",
         "--cylc_path",
-        default="~/apps",
+        default="~metomi/apps",
         help="The location of the cylc installation required for testing `next-cylc`"
         "configs.",
     )


### PR DESCRIPTION
# Description

## Summary

The cylc-8-next symlink was pointing to a later version for the first time last night since I modified the nightly cronjobs to only run when these were different. This has shown a couple of minor issues with this.

## Checklist

- [x] I have performed a self-review of my own changes
