### PR TITLE
add timeout to fcm_bdiff

### DIFF
--- a/fcm_bdiff.py
+++ b/fcm_bdiff.py
@@ -177,16 +177,20 @@ def run_fcm_command(command, max_retries, snooze):
     """
     retries = 0
     while True:
-        output = subprocess.Popen(
-            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            shell=False,
+            check=False,
         )
-        _ = output.wait()
-        if output.returncode == 0:
-            return text_decoder(output.stdout.read())
+        if result.returncode == 0:
+            return result.stdout
         else:
             retries += 1
             if retries > max_retries:
-                raise FCMError(command, text_decoder(output.stderr.read()))
+                raise FCMError(command, result.stderr)
             else:
                 time.sleep(snooze)
 


### PR DESCRIPTION
# Description

## Summary

With large changesets fcm_bdiff can fill the buffer, causing a hang - this is often seen with a non-appearing trac.log. This ticket adds a timeout to the fcm_bdiff subprocess, preventing the hang. This has been tested on a Apps branch with a large changeset.

## Changes

Add timeout to fcm_bdiff subprocess command. Also changes from subprocess.popen to subprocess.run which is a nicer interface.

## Dependency

Using subprocess.run with text=True, means fcm_bdiff now requires python3.9.


## Checklist

- [x] I have performed a self-review of my own changes
