### PR TITLE
Suite report fix

### DIFF
--- a/suite_report.py
+++ b/suite_report.py
@@ -491,13 +491,14 @@ class SuiteReport:
             proj_dict["human parent"] = self.convert_to_keyword(
                 proj_dict["parent loc"], self.projects
             )
-            proj_dict["ticket no"] = self.ascertain_ticket_number(
-                proj_dict["repo mirror"], fcm_exec
-            )
-            proj_dict["bdiff_files"] = self.get_altered_files_list(
-                proj_dict["repo mirror"]
-            )
+            # proj_dict["ticket no"] = self.ascertain_ticket_number(
+            #     proj_dict["repo mirror"], fcm_exec
+            # )
+            # proj_dict["bdiff_files"] = self.get_altered_files_list(
+            #     proj_dict["repo mirror"]
+            # )
 
+        self.debug_print_obj()
         # Check to see if ALL the groups being run fall into the
         # "common groups" category. This is used to control automatic
         # hiding of successful tasks later.
@@ -1531,6 +1532,7 @@ class SuiteReport:
                             srs_url = re.sub(proj, shared_project, url, count=1)
                         break
             else:
+                print ("using fcm info")
                 command = [fcm_exec, "info", url]
                 _, stdout, _ = _run_command(command, ignore_fail=True)
                 find_url = re.compile(r"URL:\s*(.*)")

--- a/suite_report.py
+++ b/suite_report.py
@@ -1496,15 +1496,10 @@ class SuiteReport:
         if url is None:
             return None
         srs_url = url
-        extraprint = False
-        if url.startswith("/home"):
-            extraprint=True
         for proj, proj_url in projects_dict.items():
             # Only check for keywords which correspond to mirror or SRS format
             if re.search(r".x(|m)$", proj):
                 if re.search(proj_url, url):
-                    if extraprint:
-                        print("proj_url is ", proj_url)
                     # checking given url against urls in the projects_dict
                     shared_project = re.sub(r"m$", r"", proj)
                     if shared_project in projects_dict:
@@ -1513,8 +1508,6 @@ class SuiteReport:
                         srs_url = re.sub(mirror_url, shared_url, url, count=1)
                         break
                 elif re.search("fcm:" + proj + r"[^m]", url):
-                    if extraprint:
-                        print("proj is", proj)
                     # Looking for an fcm: shorthand notation based on keyword.
                     shared_project = re.sub(r"m$", r"", proj)
                     if shared_project in projects_dict:
@@ -1539,7 +1532,6 @@ class SuiteReport:
                             srs_url = re.sub(proj, shared_project, url, count=1)
                         break
         if srs_url == url:
-            print("resorting to fcm info")
             # Only use fcm info if none of the searching through projects is successful
             command = [fcm_exec, "info", url]
             _, stdout, _ = _run_command(command, ignore_fail=True)
@@ -1549,7 +1541,6 @@ class SuiteReport:
                 if result:
                     srs_url = result.group(1).rstrip()
                     break
-        print(srs_url)
         return srs_url
 
     @staticmethod

--- a/suite_report.py
+++ b/suite_report.py
@@ -1496,10 +1496,14 @@ class SuiteReport:
         if url is None:
             return None
         srs_url = url
+        if url.startswith("/home"):
+            extraprint=True
         for proj, proj_url in projects_dict.items():
             # Only check for keywords which correspond to mirror or SRS format
             if re.search(r".x(|m)$", proj):
                 if re.search(proj_url, url):
+                    if extraprint:
+                        print("proj_url is ", proj_url)
                     # checking given url against urls in the projects_dict
                     shared_project = re.sub(r"m$", r"", proj)
                     if shared_project in projects_dict:
@@ -1508,6 +1512,8 @@ class SuiteReport:
                         srs_url = re.sub(mirror_url, shared_url, url, count=1)
                         break
                 elif re.search("fcm:" + proj + r"[^m]", url):
+                    if extraprint:
+                        print("proj is", proj)
                     # Looking for an fcm: shorthand notation based on keyword.
                     shared_project = re.sub(r"m$", r"", proj)
                     if shared_project in projects_dict:
@@ -1532,6 +1538,7 @@ class SuiteReport:
                             srs_url = re.sub(proj, shared_project, url, count=1)
                         break
         if srs_url == url:
+            print("resorting to fcm info")
             # Only use fcm info if none of the searching through projects is successful
             command = [fcm_exec, "info", url]
             _, stdout, _ = _run_command(command, ignore_fail=True)
@@ -1541,6 +1548,7 @@ class SuiteReport:
                 if result:
                     srs_url = result.group(1).rstrip()
                     break
+        print(srs_url)
         return srs_url
 
     @staticmethod

--- a/suite_report.py
+++ b/suite_report.py
@@ -1535,16 +1535,16 @@ class SuiteReport:
                         else:
                             srs_url = re.sub(proj, shared_project, url, count=1)
                         break
-            else:
-                print ("using fcm info")
-                command = [fcm_exec, "info", url]
-                _, stdout, _ = _run_command(command, ignore_fail=True)
-                find_url = re.compile(r"URL:\s*(.*)")
-                for line in stdout:
-                    result = find_url.search(line)
-                    if result:
-                        srs_url = result.group(1).rstrip()
-                        break
+                else:
+                    print ("using fcm info")
+                    command = [fcm_exec, "info", url]
+                    _, stdout, _ = _run_command(command, ignore_fail=True)
+                    find_url = re.compile(r"URL:\s*(.*)")
+                    for line in stdout:
+                        result = find_url.search(line)
+                        if result:
+                            srs_url = result.group(1).rstrip()
+                            break
         return srs_url
 
     @staticmethod

--- a/suite_report.py
+++ b/suite_report.py
@@ -1498,7 +1498,7 @@ class SuiteReport:
         srs_url = url
         for proj, proj_url in projects_dict.items():
             # Only check for keywords which correspond to mirror or SRS format
-            print("I am here")
+            print(proj, proj_url)
             if re.search(r".x(|m)$", proj):
                 if re.search(proj_url, url):
                     print("and here")
@@ -1534,17 +1534,16 @@ class SuiteReport:
                         else:
                             srs_url = re.sub(proj, shared_project, url, count=1)
                         break
-        print(srs_url)
-        if srs_url is None:
-            print ("using fcm info")
-            command = [fcm_exec, "info", url]
-            _, stdout, _ = _run_command(command, ignore_fail=True)
-            find_url = re.compile(r"URL:\s*(.*)")
-            for line in stdout:
-                result = find_url.search(line)
-                if result:
-                    srs_url = result.group(1).rstrip()
-                    break
+            else:
+                print ("using fcm info")
+                command = [fcm_exec, "info", url]
+                _, stdout, _ = _run_command(command, ignore_fail=True)
+                find_url = re.compile(r"URL:\s*(.*)")
+                for line in stdout:
+                    result = find_url.search(line)
+                    if result:
+                        srs_url = result.group(1).rstrip()
+                        break
         return srs_url
 
     @staticmethod

--- a/suite_report.py
+++ b/suite_report.py
@@ -1531,16 +1531,16 @@ class SuiteReport:
                         else:
                             srs_url = re.sub(proj, shared_project, url, count=1)
                         break
-            else:
-                print ("using fcm info")
-                command = [fcm_exec, "info", url]
-                _, stdout, _ = _run_command(command, ignore_fail=True)
-                find_url = re.compile(r"URL:\s*(.*)")
-                for line in stdout:
-                    result = find_url.search(line)
-                    if result:
-                        srs_url = result.group(1).rstrip()
-                        break
+        if srs_url is None:
+            print ("using fcm info")
+            command = [fcm_exec, "info", url]
+            _, stdout, _ = _run_command(command, ignore_fail=True)
+            find_url = re.compile(r"URL:\s*(.*)")
+            for line in stdout:
+                result = find_url.search(line)
+                if result:
+                    srs_url = result.group(1).rstrip()
+                    break
         return srs_url
 
     @staticmethod

--- a/suite_report.py
+++ b/suite_report.py
@@ -1496,10 +1496,11 @@ class SuiteReport:
         if url is None:
             return None
         srs_url = url
+        print(srs_url)
         for proj, proj_url in projects_dict.items():
             # Only check for keywords which correspond to mirror or SRS format
-            print(proj, proj_url)
             if re.search(r".x(|m)$", proj):
+                print("do I go here?")
                 if re.search(proj_url, url):
                     print("and here")
                     # checking given url against urls in the projects_dict

--- a/suite_report.py
+++ b/suite_report.py
@@ -1498,8 +1498,10 @@ class SuiteReport:
         srs_url = url
         for proj, proj_url in projects_dict.items():
             # Only check for keywords which correspond to mirror or SRS format
+            print("I am here")
             if re.search(r".x(|m)$", proj):
                 if re.search(proj_url, url):
+                    print("and here")
                     # checking given url against urls in the projects_dict
                     shared_project = re.sub(r"m$", r"", proj)
                     if shared_project in projects_dict:
@@ -1508,6 +1510,7 @@ class SuiteReport:
                         srs_url = re.sub(mirror_url, shared_url, url, count=1)
                         break
                 elif re.search("fcm:" + proj + r"[^m]", url):
+                    print("actually here")
                     # Looking for an fcm: shorthand notation based on keyword.
                     shared_project = re.sub(r"m$", r"", proj)
                     if shared_project in projects_dict:
@@ -1531,6 +1534,7 @@ class SuiteReport:
                         else:
                             srs_url = re.sub(proj, shared_project, url, count=1)
                         break
+        print(srs_url)
         if srs_url is None:
             print ("using fcm info")
             command = [fcm_exec, "info", url]

--- a/suite_report.py
+++ b/suite_report.py
@@ -498,7 +498,6 @@ class SuiteReport:
                 proj_dict["repo mirror"]
             )
 
-        self.debug_print_obj()
         # Check to see if ALL the groups being run fall into the
         # "common groups" category. This is used to control automatic
         # hiding of successful tasks later.

--- a/suite_report.py
+++ b/suite_report.py
@@ -491,12 +491,12 @@ class SuiteReport:
             proj_dict["human parent"] = self.convert_to_keyword(
                 proj_dict["parent loc"], self.projects
             )
-            # proj_dict["ticket no"] = self.ascertain_ticket_number(
-            #     proj_dict["repo mirror"], fcm_exec
-            # )
-            # proj_dict["bdiff_files"] = self.get_altered_files_list(
-            #     proj_dict["repo mirror"]
-            # )
+            proj_dict["ticket no"] = self.ascertain_ticket_number(
+                proj_dict["repo mirror"], fcm_exec
+            )
+            proj_dict["bdiff_files"] = self.get_altered_files_list(
+                proj_dict["repo mirror"]
+            )
 
         self.debug_print_obj()
         # Check to see if ALL the groups being run fall into the
@@ -1496,7 +1496,6 @@ class SuiteReport:
         if url is None:
             return None
         srs_url = url
-        print(srs_url)
         for proj, proj_url in projects_dict.items():
             # Only check for keywords which correspond to mirror or SRS format
             if re.search(r".x(|m)$", proj):
@@ -1532,15 +1531,16 @@ class SuiteReport:
                         else:
                             srs_url = re.sub(proj, shared_project, url, count=1)
                         break
-                else:
-                    command = [fcm_exec, "info", url]
-                    _, stdout, _ = _run_command(command, ignore_fail=True)
-                    find_url = re.compile(r"URL:\s*(.*)")
-                    for line in stdout:
-                        result = find_url.search(line)
-                        if result:
-                            srs_url = result.group(1).rstrip()
-                            break
+        if srs_url == url:
+            # Only use fcm info if none of the searching through projects is successful
+            command = [fcm_exec, "info", url]
+            _, stdout, _ = _run_command(command, ignore_fail=True)
+            find_url = re.compile(r"URL:\s*(.*)")
+            for line in stdout:
+                result = find_url.search(line)
+                if result:
+                    srs_url = result.group(1).rstrip()
+                    break
         return srs_url
 
     @staticmethod

--- a/suite_report.py
+++ b/suite_report.py
@@ -1500,9 +1500,7 @@ class SuiteReport:
         for proj, proj_url in projects_dict.items():
             # Only check for keywords which correspond to mirror or SRS format
             if re.search(r".x(|m)$", proj):
-                print("do I go here?")
                 if re.search(proj_url, url):
-                    print("and here")
                     # checking given url against urls in the projects_dict
                     shared_project = re.sub(r"m$", r"", proj)
                     if shared_project in projects_dict:
@@ -1511,7 +1509,6 @@ class SuiteReport:
                         srs_url = re.sub(mirror_url, shared_url, url, count=1)
                         break
                 elif re.search("fcm:" + proj + r"[^m]", url):
-                    print("actually here")
                     # Looking for an fcm: shorthand notation based on keyword.
                     shared_project = re.sub(r"m$", r"", proj)
                     if shared_project in projects_dict:
@@ -1536,7 +1533,6 @@ class SuiteReport:
                             srs_url = re.sub(proj, shared_project, url, count=1)
                         break
                 else:
-                    print ("using fcm info")
                     command = [fcm_exec, "info", url]
                     _, stdout, _ = _run_command(command, ignore_fail=True)
                     find_url = re.compile(r"URL:\s*(.*)")

--- a/suite_report.py
+++ b/suite_report.py
@@ -1496,6 +1496,7 @@ class SuiteReport:
         if url is None:
             return None
         srs_url = url
+        extraprint = False
         if url.startswith("/home"):
             extraprint=True
         for proj, proj_url in projects_dict.items():


### PR DESCRIPTION
# Description

## Summary

#83 tried to fix issues with including branches in suite report, but this doesn't seem to be working in every case - I suspect the last minute shuffle of indentation of the "else"!

This ticket makes the solution more robust by using "fcm info" to get the branch URL in any situation where the SRS URL hasn't been found another way. This also means that "fcm info" isn't called multiple times per repository which is a more effecient solution. 

## Changes

Adjusting the logic around the fcm info call. 



## Checklist

- [x] I have performed a self-review of my own changes
- [ ] I've tested this with both a UKCA and a JULES branch from a UM trunk. 
