### PR TITLE
Update suite report for azngarch

### DIFF
--- a/suite_report.py
+++ b/suite_report.py
@@ -758,13 +758,10 @@ class SuiteReport:
                 ending = ""
             project = vcs_data["url"]
 
-            prefix = "https://code.metoffice.gov.uk/svn/"
-            prefix_svn = "svn://fcm1/"
-            if project.startswith(prefix):
-                project = project[len(prefix) :]
-            if project.startswith(prefix_svn):
-                project = project[len(prefix_svn) :]
-            project = re.split("[/.]", project)[0].upper()
+            match = re.match(r"(?:https://.*?/svn/|svn://[^/]+/)([^/\./]+)",
+                             project)
+            if match:
+                project = match.group(1).upper()
             projects[project] = {}
 
             # Use the version control url as the project source

--- a/suite_report.py
+++ b/suite_report.py
@@ -88,6 +88,7 @@ FCM = {
     "ncas": "fcm",
     "psc": "fcm",
     "uoleeds": "fcm",
+    "azngarch": "fcm",
     "Unknown": "true",
 }
 RESOURCE_MONITORING_JOBS = {
@@ -107,6 +108,7 @@ RESOURCE_MONITORING_JOBS = {
     "ncas": [],
     "psc": [],
     "uoleeds": [],
+    "azngarch": [],
     "Unknown": [],
 }
 CYLC_REVIEW_URL = {
@@ -124,6 +126,7 @@ CYLC_REVIEW_URL = {
     "ncas": "http://puma.nerc.ac.uk/cylc-review",
     "psc": "Unavailable",
     "uoleeds": "Unavailable",
+    "azngarch": "Unavailable",
     "Unknown": "Unavailable",
 }
 HIGHLIGHT_ROSE_ANA_FAILS = [
@@ -166,6 +169,7 @@ COMMON_GROUPS = {
     "mss": [],
     "ncas": [],
     "psc": [],
+    "azngarch": [],
     "Unknown": [],
 }
 

--- a/suite_report.py
+++ b/suite_report.py
@@ -758,8 +758,7 @@ class SuiteReport:
                 ending = ""
             project = vcs_data["url"]
 
-            match = re.match(r"(?:https://.*?/svn/|svn://[^/]+/)([^/\./]+)",
-                             project)
+            match = re.match(r"(?:https://.*?/svn/|svn://[^/]+/)([^/\./]+)", project)
             if match:
                 project = match.group(1).upper()
             projects[project] = {}


### PR DESCRIPTION
# Description

## Summary

The `suite_report.py` script does not currently work on the NG-ARCH sandbox.  This adds support for the platform and its local mirror repository.

## Changes

These include:

* the addition of empty dictionary entries for the `azngarch` site
* the replacement of the string processing which identifies the repository with a more flexible regexp

## Impact

None.  Change should be transparent.

## Issues addressed

Resolves #85

## Checklist

- [x] I have performed a self-review of my own changes
