### PR TITLE
Fix Overly permissive regular expression range

### DIFF
--- a/suite_report.py
+++ b/suite_report.py
@@ -479,7 +479,7 @@ class SuiteReport:
             # Final attempt to ensure the links have revision numbers and not
             # keywords which aren't evaluated in the browser.
             if proj_dict["repo link"] is not None and re.search(
-                r"rev=[a-zA-z]", proj_dict["repo link"]
+                r"rev=[a-zA-Z]", proj_dict["repo link"]
             ):
                 revision = self.revision_from_loc_layout(
                     proj_dict["repo mirror"], fcm_exec

--- a/suite_report.py
+++ b/suite_report.py
@@ -485,7 +485,7 @@ class SuiteReport:
                     proj_dict["repo mirror"], fcm_exec
                 )
                 proj_dict["repo link"] = re.sub(
-                    r"rev=[a-zA-z0-9.]+",
+                    r"rev=[a-zA-Z0-9.]+",
                     "rev=" + revision,
                     proj_dict["repo link"],
                 )


### PR DESCRIPTION
# Description

## Summary

CodeQL reports overly permissive regex, due to a typo. This change should fix the warning. 

