### PR TITLE
fix kgo script

### DIFF
--- a/kgo_updates/meto_update_kgo.sh
+++ b/kgo_updates/meto_update_kgo.sh
@@ -71,6 +71,8 @@ if [[ $platforms == *"ex1a"* ]]; then
             break
         fi
     done
+else
+    ex_kgo_host="unset"
 fi
 read -rp "Suite Name: " suite_name
 read -rp "Enter the path to the merged trunk WC (top directory): " wc_path


### PR DESCRIPTION
When running on just azspice, the `ex_kgo_host` variable is undefined which causes the script to fail. This adds the variable as undefined in this case allowing the script to finish