### PR TITLE
Update release script to cope with JULES shared metadata

### DIFF
--- a/lfric_macros/release_lfric.py
+++ b/lfric_macros/release_lfric.py
@@ -99,16 +99,13 @@ def set_dependency_path(args):
         f.write("".join(x for x in lines))
 
 
-def find_meta_dirs(paths, exclude_dirs=None):
+def find_meta_dirs(paths, exclude_dirs=()):
     """
     Return a set of rose-metadata directories that can be found in the apps and
     core sources. Done by seaching for rose-meta.conf files. Records the parent
     directory of the current one, as rose-meta.conf files end up in HEAD/vnX.Y
     directories.
     """
-
-    if exclude_dirs is None:
-        exclude_dirs = []
 
     dirs = set()
     for path in paths:
@@ -409,13 +406,13 @@ def main():
     set_dependency_path(args)
 
     # Find all metadata directories, excluing jules shared and lfric inputs as these have metadata but no macros.
-    exclude_dirs = [
+    exclude_dirs = (
         ".svn",
         "rose-stem",
         "integration-test",
         "lfric-jules-shared",
         "lfricinputs",
-    ]
+    )
     meta_dirs = find_meta_dirs([args.apps, args.core], exclude_dirs)
 
     # Find JULES shared metadata directories and combine with all other metadirs for where they are handled differently

--- a/lfric_macros/release_lfric.py
+++ b/lfric_macros/release_lfric.py
@@ -99,7 +99,7 @@ def set_dependency_path(args):
         f.write("".join(x for x in lines))
 
 
-def find_meta_dirs(paths):
+def find_meta_dirs(paths, exclude_dirs=None):
     """
     Return a set of rose-metadata directories that can be found in the apps and
     core sources. Done by seaching for rose-meta.conf files. Records the parent
@@ -107,12 +107,15 @@ def find_meta_dirs(paths):
     directories.
     """
 
-    print("[INFO] Finding rose metadata directories")
+
+
+    if exclude_dirs is None:
+        exclude_dirs = []
 
     dirs = set()
     for path in paths:
+        print("[INFO] Finding rose metadata directories in", path)
         for dirpath, dirnames, filenames in os.walk(path):
-            exclude_dirs = [".svn", "rose-stem", "integration-test"]
             dirnames[:] = [d for d in dirnames if d not in exclude_dirs]
             if "rose-meta.conf" in filenames:
                 dirs.add(os.path.dirname(dirpath))
@@ -407,7 +410,14 @@ def main():
 
     set_dependency_path(args)
 
-    meta_dirs = find_meta_dirs([args.apps, args.core])
+    # Find all metadata directories, excluing jules shared and lfric inputs as these have metadata but no macros.
+    exclude_dirs = [".svn", "rose-stem", "integration-test", "lfric-jules-shared", "lfricinputs"]
+    meta_dirs = find_meta_dirs([args.apps, args.core], exclude_dirs)
+
+    # Find JULES shared metadata directories and combine with all other metadirs for where they are handled differently
+    jules_meta_path = os.path.join(args.apps, "interfaces", "jules_interface", "rose-meta", "lfric-jules-shared")
+    jules_shared_meta_dirs = find_meta_dirs([jules_meta_path])
+    meta_dirs_plus_jules = meta_dirs.union(jules_shared_meta_dirs)
 
     update_version_number(args)
 
@@ -426,7 +436,7 @@ def main():
     )
     print("\n[INFO] Successfully upgraded apps")
 
-    copy_head_meta(meta_dirs, args)
+    copy_head_meta(meta_dirs_plus_jules, args)
 
     update_meta_import_path(meta_dirs, args)
 

--- a/lfric_macros/release_lfric.py
+++ b/lfric_macros/release_lfric.py
@@ -107,8 +107,6 @@ def find_meta_dirs(paths, exclude_dirs=None):
     directories.
     """
 
-
-
     if exclude_dirs is None:
         exclude_dirs = []
 
@@ -411,11 +409,19 @@ def main():
     set_dependency_path(args)
 
     # Find all metadata directories, excluing jules shared and lfric inputs as these have metadata but no macros.
-    exclude_dirs = [".svn", "rose-stem", "integration-test", "lfric-jules-shared", "lfricinputs"]
+    exclude_dirs = [
+        ".svn",
+        "rose-stem",
+        "integration-test",
+        "lfric-jules-shared",
+        "lfricinputs",
+    ]
     meta_dirs = find_meta_dirs([args.apps, args.core], exclude_dirs)
 
     # Find JULES shared metadata directories and combine with all other metadirs for where they are handled differently
-    jules_meta_path = os.path.join(args.apps, "interfaces", "jules_interface", "rose-meta", "lfric-jules-shared")
+    jules_meta_path = os.path.join(
+        args.apps, "interfaces", "jules_interface", "rose-meta", "lfric-jules-shared"
+    )
     jules_shared_meta_dirs = find_meta_dirs([jules_meta_path])
     meta_dirs_plus_jules = meta_dirs.union(jules_shared_meta_dirs)
 


### PR DESCRIPTION
# Description

## Summary

JULES shared metadata doesn't contain any macros (these are handled seperately) so wants excluding from most of the LFRIc Apps release processes. It does still need to have a copy of the HEAD metadata at the release version. 

## Changes

* Change find_meta_dirs() to be more generic, passing in the exclude list seperately.
* Using find_meta_dirs() to seperately create a set of jules shared metadata directories from the rest and create a combined set of jules shared metadirs and the rest of the metadirs
* Use the combined set for copy_head_meta() only. 


## Checklist

- [x] I have performed a self-review of my own changes
