### PR TITLE
Validate rose meta

### DIFF
--- a/lfric_macros/validate_rose_meta.py
+++ b/lfric_macros/validate_rose_meta.py
@@ -192,6 +192,12 @@ def parse_args():
 
     args = parser.parse_args()
 
+    if not args.apps and not args.core:
+        raise RuntimeError(
+            "At least one of the Apps or Core sources must be provided as a command "
+            "line argument"
+        )
+
     if args.apps:
         args.apps = os.path.expanduser(args.apps)
     if args.core:
@@ -208,11 +214,6 @@ def main():
 
     meta_paths = ""
     rose_meta_path = ""
-    if not args.apps and not args.core:
-        raise RuntimeError(
-            "At least one of the Apps or Core sources must be provided as a command "
-            "line argument"
-        )
     if args.apps:
         source_path = args.apps
         meta_paths += f"-M {os.path.join(args.apps, "rose-meta")} "


### PR DESCRIPTION
# Description

## Summary

Refactor validate_rose_meta.py and move it to SimSys_Scripts. The script will now automatically find metadata sections and apps to validate (ignoring a list of exceptions) rather than only testing based on a hardcoded list. This was done previously and meant that new metadata sections were regularly not tested.

## Coordinated merge

This ticket needs to be committed before:
[LFRic Apps #954](https://code.metoffice.gov.uk/trac/lfric_apps/ticket/954)
[LFRic Core #4666](https://code.metoffice.gov.uk/trac/lfric/ticket/4666)


## Checklist

- [x] I have performed a self-review of my own changes
