### PR TITLE
temporary fix for kgo updates

### DIFF
--- a/kgo_updates/meto_update_kgo.sh
+++ b/kgo_updates/meto_update_kgo.sh
@@ -90,7 +90,9 @@ new_kgo_dir=${new_kgo_dir:-"vn${version_number}_t${ticket_number}"}
 # Check in the working_copy rose-stem for .rc or .cylc files
 # Need this for the variables file extension
 # Can't use Cylc version as .rc can be used in compatibility mode
-if [ -f "${wc_path}/rose-stem/suite.rc" ]; then
+# Temporary Update post UM switched to flow.cylc, but still variables.rc
+# This section can be removed once UM is just using .cylc at vn14.0
+if [ -f "${wc_path}/rose-stem/family-common.rc" ]; then
     variables_extension=".rc"
 elif [ -f "${wc_path}/rose-stem/suite.cylc" ] || [ -f "${wc_path}/rose-stem/flow.cylc" ]; then
     variables_extension=".cylc"


### PR DESCRIPTION
# Description

This script needs to work for both lfric and UM kgo, so needs to able to work with variables.cylc files and variables.rc files. It works out the extension by looking for either the flow.cylc or suite.rc in the top level rose-stem directory.
Unfortunately the UM was updated to use a flow.cylc, but didn't rename all the files. So it needs .rc extension but has a flow.cylc and so this script has broken. 
Fix temporarily by looking for family-common.rc instead of suite.rc. By vn14.0 it will use all .cylc extensions, so all this logic can be removed.

## Checklist

- [x] I have performed a self-review of my own changes
