### PR TITLE
Skip named repositories from GitHub Sync

### DIFF
--- a/git-migration/config.json
+++ b/git-migration/config.json
@@ -550,11 +550,11 @@
       "description": "Spectral data for SOCRATES",
       "trunk": "socrates/spectral",
       "tags": [
-        { "apps2.1": 1745 },
+        { "apps2.1": 1736 },
         { "apps2.2": 1829 },
-        { "um13.6": 1642 },
-        { "um13.7": 1673 },
-        { "um13.8": 1741 },
+        { "um13.6": 1613 },
+        { "um13.7": 1613 },
+        { "um13.8": 1736 },
         { "um13.9": 1829 }
       ]
     }


### PR DESCRIPTION
## Summary

We may want to skip a list of repositories from trac -> GitHub sync.  The changes enable this via `--skip=repo1,repo2`  option.

Example in dry-run mode
```bash
$ ./ssd_svn2git.sh -n -m -s mule,shumlib
2025-09-29 23:26:25 Dry run
--------------------------------------------------------------------
gitlify is /path/to/gitlify 
jq is /usr/bin/jq
gh is /usr/bin/gh
--------------------------------------------------------------------
WORKDIR: /path/to/git-migration-work-dir
CONFIG_FILE: /path/to/SimSys_Scripts/git-migration/config.json
UPDATE_GITHUB: 0
--------------------------------------------------------------------
https://metomi/svn/monc.xm/casim ....................... git@github.com:MetOffice/casim
https://metomi/svn/moci.xm/main ........................ git@github.com:MetOffice/moci
https://metomi/svn/jules.xm/main ....................... git@github.com:MetOffice/jules
https://metomi/svn/socrates.xm/main .................... git@github.com:MetOffice/socrates
https://metomi/svn/ukca.xm/main ........................ git@github.com:MetOffice/ukca
Skipping repository: shumlib
Skipping repository: mule
https://metomi/svn/um.xm/aux ........................... git@github.com:MetOffice/um_aux
https://metomi/svn/um.xm/doc ........................... git@github.com:MetOffice/um_doc
https://metomi/svn/um.xm/meta .......................... git@github.com:MetOffice/um_meta
https://metomi/svn/um.xm/main .......................... git@github.com:MetOffice/um
https://metomi/svn/gcom.xm/main ........................ git@github.com:MetOffice/gcom
https://metomi/svn/lfric_apps.xm/main .................. git@github.com:MetOffice/lfric_apps
https://metomi/svn/lfric.xm/LFRic ...................... git@github.com:MetOffice/lfric_core
https://metomi/svn/lfric.xm/GPL-utilities .............. git@github.com:MetOffice/rose_picker
https://metomi/svn/monc.xm/main ........................ git@github.com:MetOffice/monc
https://metomi/svn/socrates.xm/spectral ................ git@github.com:MetOffice/socrates-spectral
2025-09-29 23:26:26 Done.
```

Also, incorrect socrates-spectral tags are fixed.

## Dependency

None

## Impact

None

## Issues addressed

socrates-spectral sync fails due to incorrect tags

## Checklist

- [x] I have performed a self-review of my own changes
