### PR TITLE
modify log path in error message

### DIFF
--- a/suite_report.py
+++ b/suite_report.py
@@ -1998,7 +1998,7 @@ class SuiteReport:
                     "There has been an exception in SuiteReport.print_report()",
                     "See output for more information",
                     "rose-stem suite output will be in the files :\n",
-                    f"~/cylc-run/{suite_dir}/log/suite/log",
+                    f"~/cylc-run/{suite_dir}/log/scheduler/log",
                 ]
             )
         finally:


### PR DESCRIPTION
This error message still says to look in the old cylc7 path. 
Change it for cylc8.

Closes #118 