### PR TITLE
rose_meta_path appended with rose-meta for both core and apps

### DIFF
--- a/lfric_macros/validate_rose_meta.py
+++ b/lfric_macros/validate_rose_meta.py
@@ -18,6 +18,7 @@ import argparse
 # dependency
 INVALID_METADATA = [
     "jules-lfric",
+    "jules-lsm",
     "lfric-jules-shared",
     "socrates-radiation",
     "um-aerosol",
@@ -217,16 +218,16 @@ def main():
     if args.apps:
         source_path = args.apps
         meta_paths += f"-M {os.path.join(args.apps, "rose-meta")} "
-        rose_meta_path += args.apps
+        rose_meta_path += f"{os.path.join(args.apps, "rose-meta")}"
     if args.core:
         meta_paths += f"-M {os.path.join(args.core, "rose-meta")} "
         if rose_meta_path:
             # Apps has already started this
-            rose_meta_path += f":{args.core}"
+            rose_meta_path += f":{os.path.join(args.core, "rose-meta")}"
         else:
             # Apps hasn't been set
             source_path = args.core
-            rose_meta_path = args.core
+            rose_meta_path = f"{os.path.join(args.core, "rose-meta")}"
 
     if check_rose_metadata(rose_meta_path, source_path) or check_rose_stem_apps(
         meta_paths, source_path


### PR DESCRIPTION
# Description

## Summary

[lfric_apps:#1012](https://code.metoffice.gov.uk/trac/lfric_apps/ticket/1012) reoganises the JULES metadata into two metadata files. This pull request makes the relevant changes to validate_rose_meta.py.

## Changes

lfric_macros/validate_rose_meta.py

The new metadata directory **jules-lsm** has been added to the INVALID_METADATA list like **jules-lfric**, the original metadata directory. In testing the metadata changes, the meta_data_path also needed correcting by appending "rose-meta" to the core and apps paths to point to the metadata directory.

## Dependency

None that I am aware of.

## Impact

None that I am aware of.

## Issues addressed

Resolves https://github.com/MetOffice/SimSys_Scripts/issues/120

## Coordinated merge



## Checklist

- [x] I have performed a self-review of my own changes
