### PR TITLE
Update git_migration tags

### DIFF
--- a/git-migration/config.json
+++ b/git-migration/config.json
@@ -397,9 +397,7 @@
       "name": "um_meta",
       "description": "Metadata for the Met Office Unified Model (UM)",
       "trunk": "um/meta",
-      "tags": [
-        { "git_migration": 131163 }
-      ]
+      "tags": [{ "git_migration": 131163 }]
     },
     {
       "name": "um",


### PR DESCRIPTION
# Description

Update `git_migration` tags for some repositories which are now frozen on trac system.

## Summary

- [x] `um_aux@131096`
- [x] `um_meta@131163`
- [x] `gcom@1428`
- [x] `jules@31238`
- [x] `ukca@7497`

## Checklist

- [x] I have performed a self-review of my own changes
