### PR TITLE
suite_data fixes

### DIFF
--- a/github_scripts/suite_data.py
+++ b/github_scripts/suite_data.py
@@ -306,7 +306,7 @@ class SuiteData:
 
         with open(self.suite_path / "log" / "scheduler" / "log", "r") as f:
             for line in f:
-                match = re.search(r"INFO - Workflow: (\w+\/\w+)", line)
+                match = re.search(r"INFO - Workflow: (\S+\/\w+)", line)
                 try:
                     workflow_id = match.group(1)
                     return workflow_id
@@ -336,7 +336,7 @@ class SuiteData:
         for row in self.query_suite_database(
             self.suite_path / "log" / "db", ["key", "value"], "workflow_template_vars"
         ):
-            if row[0] in ("g", "groups"):
+            if row[0] in ("g", "group"):
                 groups = row[1].strip("[]'\"").split(",")
                 break
         return groups


### PR DESCRIPTION
Testing by partners has revealed a few issues with the new suite_report:

* `groups` should be `group` when reading the tasks run
* the regex for workflow names only allows [a-zA-Z0-9_] but other characters, eg. "-" are valid