### PR TITLE
Implement argument namespacing 

### DIFF
--- a/umdp3_fixer/rosestem_branch_checker.py
+++ b/umdp3_fixer/rosestem_branch_checker.py
@@ -174,7 +174,7 @@ def main():
     amp_column = opts.col
 
     (path, saved_umask, tmpdir) = copy_working_branch(model_source)
-    run_umdp3checker(model_source, fixer_source, path, amp_column)
+    run_umdp3checker(fixer_source, path, amp_column)
     diff_cwd_working(model_source, path, saved_umask, tmpdir)
 
     os.umask(saved_umask)


### PR DESCRIPTION

In #129  it was identified that the argparse library could be used in `rosestem_branch_checker.py` to provide better namespacing to arguments passed to the command line. This PR implements a small refactor to change a class and method name as well as ensuring the correct unpacking of data throughout the script. 