### PR TITLE
ignore fetch errors

### DIFF
--- a/github_scripts/get_git_sources.py
+++ b/github_scripts/get_git_sources.py
@@ -15,7 +15,7 @@ from shutil import rmtree
 
 
 def run_command(
-    command: str, rval: bool = False, check:bool = True
+    command: str, rval: bool = False, check: bool = True
 ) -> Optional[subprocess.CompletedProcess]:
     """
     Run a subprocess command and return the result object


### PR DESCRIPTION
We need to ignore errors when fetching main from the origin if main already exists in the clone