### PR TITLE
check_macro_chains to fail gracefully on FCM

### DIFF
--- a/lfric_macros/check_macro_chains.py
+++ b/lfric_macros/check_macro_chains.py
@@ -105,7 +105,6 @@ def check_fcm():
     """
     dependency = os.path.join(os.environ["SOURCE_ROOT"], "apps", "dependencies.sh")
 
-    print ("check FCM")
     if os.path.exists(dependency):
         raise Exception(
             "[ERROR] check_macro_chains.py no longer works with FCM sources. "


### PR DESCRIPTION
# Description

## Summary

On FCM we always fetched the latest version of SimSys_Scripts, but this means check_macro_chains will now always fail as the latest version has been updated to use git. Since people are still running rose-stem on FCM as part of finishing reviews and migrating I'm making the script fail in a more obvious and cleaner way in this case. I'm checking for fcm with the presence of "dependencies.sh" since this has been removed in favour of "dependencies.yaml" in the git repos. 

## Testing

The script currently fails like this: https://cylchub/services/cylc-review/view/jennifer.hickson?&suite=apps_trunk%2Frun1&no_fuzzy_time=0&path=log/job/1/macro_chains_checker/01/job.err

with my check the error now looks like this:

https://cylchub/services/cylc-review/view/jennifer.hickson?&suite=apps_trunk%2Frun5&no_fuzzy_time=0&path=log/job/1/macro_chains_checker/01/job.err

## Checklist

- [x ] I have performed a self-review of my own changes
