### PR TITLE
respect gitignore

### DIFF
--- a/github_scripts/get_git_sources.py
+++ b/github_scripts/get_git_sources.py
@@ -121,7 +121,6 @@ def sync_repo(repo_source: str, repo_ref: str, loc: Path) -> None:
     # Trailing slash required for rsync
     # Respect .gitignore for rsync
     command = f"rsync -av {repo_source}/ {loc} --filter=':- .gitignore'"
-    print("rsync command: ", command)
     run_command(command)
 
     # Fetch the main branch from origin


### PR DESCRIPTION
Respect the `.gitignore` when rsyncing local clones for the test suite. Not doing this is causing issues when the local build script has been run.
I've tested that this behaves as expected by running with the test suite from a clone with the local build output. The gitignore'd directories don't get copied. Also tested from /var/tmp to ensure it works for local filesystems.