### PR TITLE
Fix bug with extra whitespace

### DIFF
--- a/workload/workload.py
+++ b/workload/workload.py
@@ -84,14 +84,12 @@ class ProjectData:
             cr = ""
             sr = ""
             if "code Review" in review:
-                cr = review["code Review"]
-                self.review_data.append((review["code Review"], review["repository"]))
+                cr = review["code Review"].strip()
+                self.review_data.append((cr, review["repository"]))
 
             if "sciTech Review" in review:
-                sr = review["sciTech Review"]
-                self.review_data.append(
-                    (review["sciTech Review"], review["repository"])
-                )
+                sr = review["sciTech Review"].strip()
+                self.review_data.append((sr, review["repository"]))
 
             if test and (cr or sr):
                 print(


### PR DESCRIPTION
# Description

## Summary

If the username is typed into the project box with extra whitespace then workload.py won't find a match to include the review in that persons tally. Strip any extra white space when extracting the reviewers from the project data to avoid this. 