### PR TITLE
Fix run_command keywords

### DIFF
--- a/github_scripts/get_git_sources.py
+++ b/github_scripts/get_git_sources.py
@@ -165,8 +165,8 @@ def sync_repo(repo_source: str, repo_ref: str, loc: Path) -> None:
     # Ignore errors - these are likely because the main branch already exists
     # Instead write them as warnings
     command = f"git -C {loc} fetch origin main:main"
-    result = run_command(command, check=False, rval=True)
-    if result.returncode:
+    result = run_command(command, check=False)
+    if result and result.returncode:
         print("Warning - fetching main from origin resulted in an error")
         print("This is likely due to the main branch already existing")
         print(f"Error message:\n\n{result.stderr}")


### PR DESCRIPTION
# Description

## Summary

Fix keyword error in run_command call that was overlooked in #164

## Changes

Remove unexpected `rval` keyword from `run_command()` call

## Dependency

None


## Issues addressed

Fixes

```
TypeError: run_command() got an unexpected keyrod argument 'rval'
```

## Checklist

- [x] I have performed a self-review of my own changes
