### PR TITLE
Option to check whole repository/directory

### DIFF
--- a/script_umdp3_checker/umdp3_conformance.py
+++ b/script_umdp3_checker/umdp3_conformance.py
@@ -574,7 +574,7 @@ if __name__ == "__main__":
     log_volume = args.volume
 
     file_paths = get_files_to_check(args.path, args.fullcheck, log_volume)
-    full_file_paths = [Path(f"{args.path}/{f}") for f in file_paths]
+    full_file_paths = [Path(args.path) / f for f in file_paths]
 
     # Configure checkers
     """


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: @Pierre-siddall 
Code Reviewer: @jennyhickson 

A change to add a command line argument whichrather than checking with a CMS for a list of changed files, uses glob to assemble a list of all files within a direcotry (or local repository clone)
As such, adds a block for the new, logical, argument.
Creates a new subroutine to decide whether to ask a CMS or use glob.
Refactors the bit that used to output info about the branch and the files found to within the routine that decides which CMS to use before passing the CMS object back to the new routine which creates the list of files to check.

- is linked with #173
Which was a pre-requisite, now merged.


Still stacking those PRs


## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] This change has been tested appropriately (please describe)

Change run, on command line of VDI, against other peoples ukca and um branches both with and without `--fullcheck`. The results were as expected.

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## AI Assistance and Attribution

- [x] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->
AI used (GitHub Copilot) as it is enabled to provide inline hinting and completion. It's responsibe for those two horrendously verbose (by even my standards) docstrings, which I accepted purely for amusment's sake.

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [x] All dependencies have been resolved
- [x] Related Issues have been properly linked and addressed
- [x] Code quality standards have been met
- [x] Tests are adequate and have passed
- [x] Security considerations have been addressed
- [x] Performance impact is acceptable

