### PR TITLE
Adjust file types to be a set, making the inclusion of 'group' types trivial

### DIFF
--- a/script_umdp3_checker/umdp3_conformance.py
+++ b/script_umdp3_checker/umdp3_conformance.py
@@ -547,10 +547,10 @@ def detangle_file_types(file_types: Set[str]) -> Set[str]:
         # sync with what's allowable...
         if file_types.difference(the_whole_world):
             raise ValueError(
-                "Invalid file types specified: " +
-                f"{file_types.difference(the_whole_world)}" +
-                f" in group \"{group}\""
-                )
+                "Invalid file types specified: "
+                + f"{file_types.difference(the_whole_world)}"
+                + f' in group "{group}"'
+            )
     return file_types
 
 
@@ -561,8 +561,7 @@ def create_style_checkers(
     dispatch_tables = CheckerDispatchTables()
     checkers = []
     if "Fortran" in file_types:
-        file_extensions = {".f", ".for", ".f90", ".f95",
-                           ".f03", ".f08", ".F90"}
+        file_extensions = {".f", ".for", ".f90", ".f95", ".f03", ".f08", ".F90"}
         """
         TODO : I /think/ the old version also checked '.h' files as Fortran.
         Not sure if that is still needed."""


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: @Pierre-siddall 
Code Reviewer: @cameronbateman-mo 

Subtle shit in the options for "file types" to store as a set which makes setting up "group" file -types, i.e. ones which resolve into multiple others, trivial.

I've added a demo one called CI, which will currently check Fortran and Python files.

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] This change has been tested appropriately (please describe)

I ran the umdp3 checker on it's containing branch.
The group filetype 'CI' corectly resolved to check "Fortran, Python" files
running pytest on the script_umdp3_checker directory returns no failures.

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## AI Assistance and Attribution

- [x] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

GitHub CoPilot is turned on for "command completeion" when editing files. Some of the things it suggested were close enough to what was in my head that I accepted them.

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable

