### PR TITLE
update suite_report to use cylc-run sources

### DIFF
--- a/github_scripts/suite_data.py
+++ b/github_scripts/suite_data.py
@@ -10,7 +10,6 @@ Class containing helper methods for gathering data needed for a SuiteReport obje
 
 import re
 import os
-import shutil
 import sqlite3
 import subprocess
 import yaml
@@ -18,8 +17,6 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Union
 from git_bdiff import GitBDiff, GitInfo
-from get_git_sources import clone_repo, sync_repo
-
 
 class SuiteData:
     """
@@ -36,12 +33,12 @@ class SuiteData:
         "-v-",
     )
 
-    def __init__(self, suite_path=None) -> None:
+    def __init__(self, suite_path: Path = None) -> None:
         self.dependencies = {}
         self.rose_data = {}
         self.suite_path = suite_path
+        self.source_root = suite_path / "share" / "source"
         self.task_states = {}
-        self.temp_directory = None
 
     def get_um_failed_configs(self) -> Set[str]:
         """
@@ -65,7 +62,7 @@ class SuiteData:
         """
         Read through a UM file searching for line
         """
-        change = self.temp_directory / "um" / change
+        change = self.source_root / "um" / change
         lines = change.read_text()
         lines = lines.lower()
         try:
@@ -118,7 +115,7 @@ class SuiteData:
         Read UM Code Owners file and write to a dictionary
         """
 
-        fpath = self.temp_directory / "um" / filename
+        fpath = self.source_root / "um" / filename
         owners_text = fpath.read_text()
 
         in_owners = False
@@ -179,7 +176,7 @@ class SuiteData:
             if not data["gitinfo"].is_main():
                 parent = "main"
                 self.dependencies[dependency]["gitbdiff"] = GitBDiff(
-                    repo=self.temp_directory / dependency, parent=parent
+                    repo=self.source_root / dependency, parent=parent
                 ).files()
             else:
                 self.dependencies[dependency]["gitbdiff"] = []
@@ -191,22 +188,8 @@ class SuiteData:
 
         for dependency in self.dependencies:
             self.dependencies[dependency]["gitinfo"] = GitInfo(
-                self.temp_directory / dependency
+                self.source_root / dependency
             )
-
-    def clone_sources(self) -> None:
-        """
-        Clone the sources defined in the dependencies file, to allow reading of files
-        and creation of diffs.
-        If the source is not a github url, then copy it using rsync
-        """
-
-        for dependency, data in self.dependencies.items():
-            loc = self.temp_directory / dependency
-            if data["source"].endswith(".git"):
-                clone_repo(data["source"], data["ref"], loc)
-            else:
-                sync_repo(data["source"], data["ref"], loc)
 
     def determine_primary_source(self) -> str:
         """
@@ -418,9 +401,3 @@ class SuiteData:
             )
         if rval:
             return result
-
-    def cleanup(self) -> None:
-        """
-        Remove self.temp_directory
-        """
-        shutil.rmtree(self.temp_directory)

--- a/github_scripts/suite_data.py
+++ b/github_scripts/suite_data.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set, Union
 from git_bdiff import GitBDiff, GitInfo
 
+
 class SuiteData:
     """
     Class to gather info on a suite

--- a/github_scripts/suite_report_git.py
+++ b/github_scripts/suite_report_git.py
@@ -16,7 +16,6 @@ import sys
 from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
-from tempfile import mkdtemp
 from typing import Dict, List, Set, Tuple
 
 from suite_data import SuiteData
@@ -79,8 +78,6 @@ class SuiteReport(SuiteData):
         self.rose_data: Dict[str, str] = self.read_rose_conf()
         self.dependencies: Dict[str, Dict] = self.read_dependencies()
         self.primary_source: str = self.determine_primary_source()
-        self.temp_directory = Path(mkdtemp())
-        self.clone_sources()
         self.populate_gitinfo()
         self.populate_gitbdiff()
         self.trac_log = []
@@ -90,7 +87,7 @@ class SuiteReport(SuiteData):
         Find the branch name or hash and remote reference for a given source
         """
 
-        source = self.temp_directory / source
+        source = self.source_root / source
 
         branch_name = self.run_command(
             f"git -C {source} branch --show-current", rval=True
@@ -361,8 +358,11 @@ def parse_args() -> argparse.Namespace:
 
     args, _ = parser.parse_known_args()
 
-    # Check log file is writable, set as None if not (this will output to stdout)
-    if args.log_path and not os.access(args.log_path, os.W_OK):
+    # Default log_path as suite_path if not set, then check log file is writable
+    # set as None if not (this will output to stdout)
+    if not args.log_path:
+        args.log_path = args.suite_path
+    if not os.access(args.log_path, os.W_OK):
         args.log_path = None
 
     return args
@@ -376,11 +376,8 @@ def main() -> None:
     args = parse_args()
 
     suite_report = SuiteReport(args.suite_path)
-    try:
-        suite_report.create_log()
-        suite_report.write_log(args.log_path)
-    finally:
-        suite_report.cleanup()
+    suite_report.create_log()
+    suite_report.write_log(args.log_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @t00sa

<!-- To be completed by the developer -->

This changes suite_report to use the source code extracted by the rose-stem suite when identifying branch information, rather than extracting it itself. This should prevent issues when a local clone is switched to a new branch during the run. I had thought the housekeeping tasks would need updating to avoid deleting these extracted clones, but it turns out none of the suites remove that.

This also corrects the log_file logic so that it defaults to the suite path, as was the original intention.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] This change has been tested appropriately (please describe)

Tested using a random UM branch - output below:

# Test Suite Results - um - um_test/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [um_test/run1](https://cylchub/services/cylc-review/cycles/james.bruten/?suite=um_test%2Frun1) |
| Suite User | james.bruten |
| Workflow Start | 2026-04-15T10:14:33 |
| Groups Run | check_groups_coverage |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.03.1](https://github.com/MetOffice/casim/tree/2026.03.1) | True |
| jules | [MetOffice/jules@2026.03.1](https://github.com/MetOffice/jules/tree/2026.03.1) | True |
| moci | [MetOffice/moci@2026.03.1](https://github.com/MetOffice/moci/tree/2026.03.1) | True |
| mule | [MetOffice/mule@2026.03.1](https://github.com/MetOffice/mule/tree/2026.03.1) | True |
| shumlib | [MetOffice/shumlib@2026.03.1](https://github.com/MetOffice/shumlib/tree/2026.03.1) | True |
| socrates | [MetOffice/socrates@2026.03.1](https://github.com/MetOffice/socrates/tree/2026.03.1) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@2026.03.1](https://github.com/MetOffice/SimSys_Scripts/tree/2026.03.1) | True |
| ukca | [MetOffice/ukca@2026.03.1](https://github.com/MetOffice/ukca/tree/2026.03.1) | True |
| um | [james-bruten-mo/um@um14.1_release](https://github.com/james-bruten-mo/um/tree/um14.1_release) | False |
| um_aux | [MetOffice/um_aux@2026.03.1](https://github.com/MetOffice/um_aux/tree/2026.03.1) | True |
| um_meta | [MetOffice/um_meta@2026.03.1](https://github.com/MetOffice/um_meta/tree/2026.03.1) | True |

## Approvals
### Code Owners
| Section | Owner | Deputy | State |
| :--- | :--- | :--- | :--- |
| rose_stem | jamesbruten | roddysharp | Pending |
| top_level | jenniferhickson | samclarkegreen | Pending |
| admin | SSD Team | -- | Pending |
| stash | roddysharp | ericaneininger | Pending |
| upgrade_macros | ericaneininger | jamesbruten | Pending |
| bin | SSD Team | -- | Pending |
### Config Owners
No UM Config Owners Required
## Task Information
:white_check_mark: succeeded tasks - 5


## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable

