### PR TITLE
General Improvements to umdp3 checker 

### DIFF
--- a/script_umdp3_checker/tests/example_fortran_code.F90
+++ b/script_umdp3_checker/tests/example_fortran_code.F90
@@ -45,9 +45,10 @@ IMPLICIT NONE
 INTEGER, INTENT(IN) :: xlen !Length of first dimension of the arrays.
 INTEGER, INTENT(IN) :: ylen !Length of second dimension of the arrays.
 LOGICAL, INTENT(IN) :: l_unscale ! switch scaling off.
-REAL, INTENT(IN) :: input1(xlen, ylen) !First input array
-REAL, INTENT(IN OUT) :: input2(xlen, ylen) !Second input array
-REAL, INTENT(OUT) :: output(xlen, ylen) !Contains the result
+REAL, INTENT(IN)     :: input1(xlen, ylen) !First input array
+REAL, INTENT(IN OUT) :: input2(xlen, ylen) ! INOUT Second input array
+REAL, INTENT(OUT)    :: output(xlen, ylen) !Contains the result
+REAL, PARAMETER :: b_pollonator(4)  = [ 0.0,    11.2,   6.6,    3.6]
 LOGICAL, INTENT(IN), OPTIONAL :: l_loud_opt !optional debug flag
 ! Local variables
 INTEGER(KIND=jpim), PARAMETER :: zhook_in = 0 ! DrHook tracing entry

--- a/script_umdp3_checker/tests/test_fortran_checks.py
+++ b/script_umdp3_checker/tests/test_fortran_checks.py
@@ -84,6 +84,18 @@ unseparated_keywords_parameters = [
     (["i=0", "i=i+1", "PRINT*,i"], 0, "No keywords"),
     (["PROGRAM test", "i=0", "ENDIF"], 1, "One keyword unseparated"),
     (["i=0", "ENDPARALLELDO", "END DO"], 1, "One keyword unseparated in middle"),
+    (
+        [
+            "REAL, INTENT(IN OUT) ::   lambda_pole   !INOUT  Longitude of pole",
+            "REAL, INTENT(OUT)  :: Dave",
+            "DO",
+            "nothing",
+            "END DO",
+        ],
+        0,
+        "unseparated keyword in comment",
+    ),
+    (["#endif", "i=i+1", "PRINT*,i"], 0, "Safely ignore cpp commands"),
 ]
 
 

--- a/script_umdp3_checker/tests/test_umdp3_conformance.py
+++ b/script_umdp3_checker/tests/test_umdp3_conformance.py
@@ -525,7 +525,7 @@ def test_conformance_checker_print_results_volume4_prints_error_details(
     capsys: pytest.CaptureFixture[str],
 ):
     fail_tr = SimpleNamespace(
-        checker_name="RuleZ", failure_count=2, passed=False, errors={"RuleZ": "detail"}
+        checker_name="RuleZ", failure_count=2, passed=False, errors={"RuleZ": [10, 20]}
     )
 
     cc = ConformanceChecker([])
@@ -539,7 +539,7 @@ def test_conformance_checker_print_results_volume4_prints_error_details(
     conformance checker just to check the detail text from the test was in the output
     written"""
     assert "RuleZ" in out
-    assert "detail" in out
+    assert "10 and 20" in out
 
 
 def test_stylechecker_check_with_no_check_functions_passes(tmp_path: Path):

--- a/script_umdp3_checker/tests/test_umdp3_rules_S3.py
+++ b/script_umdp3_checker/tests/test_umdp3_rules_S3.py
@@ -146,8 +146,6 @@ def test_concatenate_lines(example_fortran_lines):
 @pytest.mark.parametrize(
     "changes_list, expected_passed, expected_failure_count, expected_errors",
     [
-        # Valid: MODULE example_mod ... END MODULE example_mod (no changes)
-        ([], True, 0, {}),
         # Invalid: No program unit found (delete MODULE line)
         (
             [["replace", 12, ["! No module declaration here"]]],
@@ -160,7 +158,7 @@ def test_concatenate_lines(example_fortran_lines):
         ),
         # Invalid: Mismatched END statement
         (
-            [["replace", 120, ["END MODULE wrong_mod_name"]]],
+            [["replace", 121, ["END MODULE wrong_mod_name"]]],
             False,
             1,
             {
@@ -171,7 +169,7 @@ def test_concatenate_lines(example_fortran_lines):
         ),
         # Invalid: No END statement found
         (
-            [["replace", 120, ["! Missing END MODULE"]]],
+            [["replace", 121, ["! Missing END MODULE"]]],
             False,
             1,
             {
@@ -180,12 +178,22 @@ def test_concatenate_lines(example_fortran_lines):
                 ]
             },
         ),
+        # Pass ccp directives #if !defined(MCT)
+        (
+            [["replace", 1, ["#if !defined(MCT)"]], ["add", 121, ["#endif"]]],
+            True,
+            0,
+            {},
+        ),
+        # Valid: MODULE example_mod ... END MODULE example_mod (no changes)
+        ([], True, 0, {}),
     ],
     ids=[
-        "Valid module with matching END",
         "No program unit found",
         "Mismatched END statement",
         "No END statement",
+        "Valid checking cpp directives pass",
+        "Valid module with matching END",
     ],
 )
 def test_r3_1_1_there_can_be_only_one(
@@ -197,15 +205,15 @@ def test_r3_1_1_there_can_be_only_one(
 ):
     modified_fortran_lines = modify_fortran_lines(example_fortran_lines, changes_list)
     result = r3_1_1_there_can_be_only_one(modified_fortran_lines)
-    assert result.passed == expected_passed
-    assert result.failure_count == expected_failure_count
     errors = result.errors
-    assert len(errors) == len(expected_errors)
     for error, lines_list in errors.items():
         assert error in expected_errors
-        assert len(lines_list) == len(expected_errors[error])
         for line_no in lines_list:
             assert line_no in expected_errors[error]
+        assert len(lines_list) == len(expected_errors[error])
+    assert len(errors) == len(expected_errors)
+    assert result.failure_count == expected_failure_count
+    assert result.passed == expected_passed
 
 
 # =================================================================
@@ -236,14 +244,14 @@ def test_r3_2_1_check_crown_copyright(
     modified_fortran_lines = modify_fortran_lines(example_fortran_lines, changes_list)
     result = r3_2_1_check_crown_copyright(modified_fortran_lines)
     failure_count = result.failure_count
-    assert failure_count == expected_result
     errors = result.errors
-    assert len(errors) == len(expected_errors)
     for error, lines_list in errors.items():
         assert error in expected_errors
-        assert len(lines_list) == len(expected_errors[error])
         for line_no in lines_list:
             assert line_no in expected_errors[error]
+        assert len(lines_list) == len(expected_errors[error])
+    assert len(errors) == len(expected_errors)
+    assert failure_count == expected_result
 
 
 # =================================================================
@@ -270,7 +278,6 @@ def test_r3_2_1_check_crown_copyright(
                         + '":"  //  RoutineName,  zhook_out,  zhook_handle) ! extra comment'
                     ],
                 ],
-                ["replace", 42, ["use yomhook, ONLY: lhook, dr_hook"]],
             ],
             2,
             {"line too long": [73, 117]},
@@ -286,14 +293,14 @@ def test_r3_3_2_line_too_long(
     modified_fortran_lines = modify_fortran_lines(example_fortran_lines, changes_list)
     result = r3_3_2_line_too_long(modified_fortran_lines)
     failure_count = result.failure_count
-    assert failure_count == expected_result
     errors = result.errors
-    assert len(errors) == len(expected_errors)
     for error, lines_list in errors.items():
         assert error in expected_errors
-        assert len(lines_list) == len(expected_errors[error])
         for line_no in lines_list:
             assert line_no in expected_errors[error]
+        assert len(lines_list) == len(expected_errors[error])
+    assert len(errors) == len(expected_errors)
+    assert failure_count == expected_result
 
 
 # =================================================================
@@ -311,9 +318,27 @@ def test_r3_3_2_line_too_long(
             3,
             {"lowercase keyword: Module": [12], "lowercase keyword: use": [39, 42]},
         ),
+        (
+            [
+                ["add", 44, ["#if defined(SOMETHING)"]],
+                [
+                    "add",
+                    47,
+                    [
+                        "#else",
+                        "INTEGER, INTENT(INOUT) :: xlen",
+                        "INTEGER, INTENT(OUT) :: ylen",
+                        "LOGICAL, INTENT(IN) :: l_WhoopSies = .FALSE.",
+                        "#endif",
+                    ],
+                ],
+            ],
+            0,
+            {},
+        ),
         ([], 0, {}),  # No changes, expect no errors
     ],
-    ids=["3 Lowercase Errors", "No Lowercase Errors"],
+    ids=["3 Lowercase Errors", "Pass cpp directives", "No Lowercase Errors"],
 )
 def test_r3_4_1_capitalised_keywords(
     example_fortran_lines, changes_list, expected_result, expected_errors
@@ -321,14 +346,14 @@ def test_r3_4_1_capitalised_keywords(
     modified_fortran_lines = modify_fortran_lines(example_fortran_lines, changes_list)
     result = r3_4_1_capitalised_keywords(modified_fortran_lines)
     failure_count = result.failure_count
-    assert failure_count == expected_result
     errors = result.errors
-    assert len(errors) == len(expected_errors)
     for error, lines_list in errors.items():
         assert error in expected_errors
-        assert len(lines_list) == len(expected_errors[error])
         for line_no in lines_list:
             assert line_no in expected_errors[error]
+        assert len(lines_list) == len(expected_errors[error])
+    assert len(errors) == len(expected_errors)
+    assert failure_count == expected_result
 
 
 # =================================================================
@@ -345,19 +370,21 @@ def test_r3_4_1_capitalised_keywords(
                     45,
                     ["INTEGER, INTENT(IN) :: XLEN !Length of first dim of the arrays."],
                 ],
-                ["replace", 60, ["REAL :: var1, DAVE_2, HiPPo"]],
+                ["replace", 61, ["REAL :: var1, DAVE_2, HiPPo"]],
             ],
             2,
             {
-                "Found UPPERCASE variable name in declaration at line 45: XLEN": [45],
-                "Found UPPERCASE variable name in declaration at line 60: DAVE_2": [60],
+                'Found UPPERCASE variable name in declaration at line 45: "XLEN"': [45],
+                'Found UPPERCASE variable name in declaration at line 61: "DAVE_2"': [
+                    61
+                ],
             },
         ),
         (
             [
                 [
                     "add",
-                    58,
+                    59,
                     ["LOGICAL :: l_whizz_bang = .FALSE. ! optimisation flag"],
                 ],
             ],
@@ -368,7 +395,7 @@ def test_r3_4_1_capitalised_keywords(
             [
                 [
                     "add",
-                    60,
+                    61,
                     [
                         "REAL      :: VARIaBLE_1, variable_2,          &",
                         "     VARIABLE_3, Hot_Potato, Baked Potato     &",
@@ -378,7 +405,7 @@ def test_r3_4_1_capitalised_keywords(
                 ],
                 [
                     "replace",
-                    56,
+                    57,
                     [
                         "INTEGER :: j ! Loop counter   &",
                         "INTEGER :: k ! Loop counter   &",
@@ -396,18 +423,50 @@ def test_r3_4_1_capitalised_keywords(
             ],
             5,
             {
-                "Found UPPERCASE variable name in declaration at line 45: XLEN": [45],
-                "Found UPPERCASE variable name in declaration at line 58: IJ": [58],
-                "Found UPPERCASE variable name in declaration at line 62: CASPVAR": [
-                    62
+                'Found UPPERCASE variable name in declaration at line 45: "XLEN"': [45],
+                'Found UPPERCASE variable name in declaration at line 59: "IJ"': [59],
+                'Found UPPERCASE variable name in declaration at line 63: "CASPVAR"': [
+                    63
                 ],
-                "Found UPPERCASE variable name in declaration at line 62: VARIABLE_3": [
-                    62
+                'Found UPPERCASE variable name in declaration at line 63: "VARIABLE_3"': [
+                    63
                 ],
-                "Found UPPERCASE variable name in declaration at line 62: CAPS_VAR": [
-                    62
+                'Found UPPERCASE variable name in declaration at line 63: "CAPS_VAR"': [
+                    63
                 ],
             },
+        ),
+        (
+            [
+                ["delete", 48, None],
+                [
+                    "replace",
+                    49,
+                    [
+                        "REAL, INTENT(IN) :: input1(xlen, ylen),   & !First input array",
+                        "                    input2(XLEN, ylen), !Second input array",
+                    ],
+                ],
+                # [],
+            ],
+            0,
+            {},
+        ),
+        (
+            [
+                ["delete", 48, None],
+                [
+                    "replace",
+                    49,
+                    [
+                        "REAL, INTENT(IN) :: input1(xlen, ylen),   & !First input array",
+                        "                    INPUT2(XLEN, ylen), !Second input array",
+                    ],
+                ],
+                # [],
+            ],
+            1,
+            {'Found UPPERCASE variable name in declaration at line 48: "INPUT2"': [48]},
         ),
         ([], 0, {}),  # No changes, expect no errors
     ],
@@ -415,6 +474,8 @@ def test_r3_4_1_capitalised_keywords(
         "2 UpperCase Var Errors",
         "False FALSE error",
         "5 UpperCase Var Errors on extended lines",
+        "Array dimnensions, twice on an extended line, but no failures",
+        "Array dimnensions, twice on an extended line, with one failure",
         "No UpperCase Var Errors",
     ],
 )
@@ -424,11 +485,16 @@ def test_r3_4_2_no_full_uppercase_variable_names(
     modified_fortran_lines = modify_fortran_lines(example_fortran_lines, changes_list)
     result = r3_4_2_no_full_uppercase_variable_names(modified_fortran_lines)
     failure_count = result.failure_count
-    assert failure_count == expected_result
     errors = result.errors
-    assert len(errors) == len(expected_errors)
     for error, lines_list in errors.items():
         assert error in expected_errors
-        assert len(lines_list) == len(expected_errors[error])
         for line_no in lines_list:
             assert line_no in expected_errors[error]
+        assert len(lines_list) == len(expected_errors[error])
+    assert len(errors) == len(expected_errors)
+    assert failure_count == expected_result
+
+
+"""TODO: When testing for 'unseparated keywords' remember to test/discard false +ves on
+"#endif" or similar. Current (old) test flags these in the wild, but the example file
+has no  cpp directives..."""

--- a/script_umdp3_checker/tests/test_umdp3_rules_S3.py
+++ b/script_umdp3_checker/tests/test_umdp3_rules_S3.py
@@ -468,6 +468,23 @@ def test_r3_4_1_capitalised_keywords(
             1,
             {'Found UPPERCASE variable name in declaration at line 48: "INPUT2"': [48]},
         ),
+        (
+            [
+                [
+                    "add",
+                    51,
+                    [
+                        "REAL(KIND=real_umphys), INTENT(IN OUT)  ::                      &",
+                        "                        variable(                               &",
+                        " (1-halox):(proc_row_length+halox),                             &",
+                        " (1-haloy):(proc_rows+haloy),                                   &",
+                        "  1:model_levels )                        ! Model variable",
+                    ]
+                ]
+            ],
+            0,
+            {}
+        ),  # Real world false Fail, Thanks Andy M.
         ([], 0, {}),  # No changes, expect no errors
     ],
     ids=[
@@ -476,6 +493,7 @@ def test_r3_4_1_capitalised_keywords(
         "5 UpperCase Var Errors on extended lines",
         "Array dimnensions, twice on an extended line, but no failures",
         "Array dimnensions, twice on an extended line, with one failure",
+        "Weird real world error from Andy M",
         "No UpperCase Var Errors",
     ],
 )

--- a/script_umdp3_checker/tests/test_umdp3_rules_S3.py
+++ b/script_umdp3_checker/tests/test_umdp3_rules_S3.py
@@ -479,11 +479,11 @@ def test_r3_4_1_capitalised_keywords(
                         " (1-halox):(proc_row_length+halox),                             &",
                         " (1-haloy):(proc_rows+haloy),                                   &",
                         "  1:model_levels )                        ! Model variable",
-                    ]
+                    ],
                 ]
             ],
             0,
-            {}
+            {},
         ),  # Real world false Fail, Thanks Andy M.
         ([], 0, {}),  # No changes, expect no errors
     ],

--- a/script_umdp3_checker/umdp3_checker_rules.py
+++ b/script_umdp3_checker/umdp3_checker_rules.py
@@ -134,7 +134,9 @@ class UMDP3Checker:
             if line.lstrip(" ").startswith("!"):
                 continue
             clean_line = self.remove_quoted(line)
-            for pattern in [f"\\b{kw}\\b" for kw in unseparated_keywords_list]:
+            clean_line = self.comment_line.sub("", clean_line).strip()
+            # The [^#] is to avoid false positives on #endif and similar.
+            for pattern in [f"([^#]|^)\\b{kw}\\b" for kw in unseparated_keywords_list]:
                 if re.search(pattern, clean_line, re.IGNORECASE):
                     failures += 1
                     error_log = self.add_error_log(
@@ -158,7 +160,7 @@ class UMDP3Checker:
         count = -1
         for count, line in enumerate(lines):
             clean_line = self.remove_quoted(line)
-            clean_line = re.sub(r"!.*$", "", clean_line)
+            clean_line = self.comment_line.sub("", clean_line).strip()
 
             if match := re.search(r"\bGO\s*TO\s+(\d+)", clean_line, re.IGNORECASE):
                 label = match.group(1)

--- a/script_umdp3_checker/umdp3_conformance.py
+++ b/script_umdp3_checker/umdp3_conformance.py
@@ -360,7 +360,15 @@ class ConformanceChecker:
                         for count, (title, info) in enumerate(
                             test_result.errors.items()
                         ):
-                            print(" " * 8 + f"{count + 1:2} : {title} : {info}")
+                            if len(info) == 1 and info[0] == 0:
+                                print(" " * 8 + f"{count + 1:2} : {title}")
+                            else:
+                                plural = "" if len(info) == 1 else "s"
+                                print(" " * 8 + f"{count + 1:2} : " +
+                                      f"{title} at line{plural} : " +
+                                      f"{", ".join([str(x) for x in info[:-1]])}" +
+                                      f"{' and ' if len(info) > 1 else ''}" +
+                                      f"{info[-1] if info else ''}")
                         print(" " * 8 + line_2(82))
                 elif print_volume >= 3:
                     print(f"     {test_result.checker_name:60s} : ✓ PASS")

--- a/script_umdp3_checker/umdp3_conformance.py
+++ b/script_umdp3_checker/umdp3_conformance.py
@@ -364,11 +364,14 @@ class ConformanceChecker:
                                 print(" " * 8 + f"{count + 1:2} : {title}")
                             else:
                                 plural = "" if len(info) == 1 else "s"
-                                print(" " * 8 + f"{count + 1:2} : " +
-                                      f"{title} at line{plural} : " +
-                                      f"{", ".join([str(x) for x in info[:-1]])}" +
-                                      f"{' and ' if len(info) > 1 else ''}" +
-                                      f"{info[-1] if info else ''}")
+                                print(
+                                    " " * 8
+                                    + f"{count + 1:2} : "
+                                    + f"{title} at line{plural} : "
+                                    + f"{', '.join([str(x) for x in info[:-1]])}"
+                                    + f"{' and ' if len(info) > 1 else ''}"
+                                    + f"{info[-1] if info else ''}"
+                                )
                         print(" " * 8 + line_2(82))
                 elif print_volume >= 3:
                     print(f"     {test_result.checker_name:60s} : ✓ PASS")

--- a/script_umdp3_checker/umdp3_rules_S3.py
+++ b/script_umdp3_checker/umdp3_rules_S3.py
@@ -24,6 +24,7 @@ from fortran_keywords import fortran_keywords
 # from script_umdp3_checker import fortran_keywords
 
 comment_line = re.compile(r"!.*$")
+cpp_command_line = re.compile(r"^#.*$")
 word_splitter = re.compile(r"\b\w+\b")
 
 
@@ -77,8 +78,16 @@ def create_unique_random_string(storage_set, length: int = 7) -> str:
 
 def remove_comments(line: str) -> str:
     """Remove comments from the lines :
-    There is a bit of an assumption here that quoted text has already been removed, so that we don't accidentally remove text after an "!" in a string."""
+    There is a bit of an assumption here that quoted text has already been removed, so
+    that we don't accidentally remove text after an "!" in a string."""
     return comment_line.sub("", line).rstrip()
+
+
+def remove_cpp_commands(line: str) -> str:
+    """Remove cpp commands from the lines :
+    There is a bit of an assumption here that quoted text has already been removed, so that we don't accidentally remove text after an "#" in a string.
+    Also that cpp commands have the '#' in col 1 of the line."""
+    return cpp_command_line.sub("", line).rstrip()
 
 
 def concatenate_lines(lines: List[str], line_no: int) -> str:
@@ -118,6 +127,7 @@ def r3_1_1_there_can_be_only_one(
     def find_first(lines: List[str]) -> tuple[bool, str]:
         for line in lines:
             executable_line = remove_comments(line).strip()
+            executable_line = remove_cpp_commands(executable_line).strip()
             if not executable_line:
                 continue  # Skip empty lines
             for keyword in program_unit_keywords:
@@ -136,6 +146,7 @@ def r3_1_1_there_can_be_only_one(
     def find_last(lines: List[str], unit_type: str, unit_name: str) -> tuple[bool, str]:
         for line in reversed(lines):
             executable_line = remove_comments(line).strip()
+            executable_line = remove_cpp_commands(executable_line).strip()
             if not executable_line:
                 continue  # Skip empty lines
             unit_name_search = re.search(rf"END\s+{unit_type}\s+(\w+)", executable_line)
@@ -285,6 +296,7 @@ def r3_4_1_capitalised_keywords(lines: List[str]) -> TestResult:
             continue
         clean_line = remove_quoted(line)
         clean_line = comment_line.sub("", clean_line)
+        clean_line = remove_cpp_commands(clean_line)
         # Check for lowercase keywords
         for word in word_splitter.findall(clean_line):
             upcase = word.upper()
@@ -323,6 +335,13 @@ TODO: This is a very simplistic check and will not detect many
     declaration_search = re.compile(
         r"^\s*(INTEGER|REAL|LOGICAL|CHARACTER|TYPE)\s*.*::\s*", re.IGNORECASE
     )
+    digit_search = re.compile(r"([+-]?\d+\.\d+|[+-]?\d+)")
+    array_dimensions_search = re.compile(
+        r"\([^)]*\)"
+    )  # finds array dimensions in declaration
+    array_assignment_search = re.compile(
+        r"=\s*\[[^\]]*\]\s*"
+    )  # finds array assignments
     for count, line in enumerate(lines, 1):
         clean_line = remove_quoted(line)
         clean_line = remove_comments(clean_line)
@@ -330,15 +349,19 @@ TODO: This is a very simplistic check and will not detect many
         if declaration_search.search(clean_line):
             full_line = concatenate_lines(lines, count)
             clean_line = full_line.split("::", 1)[1].strip()
-            clean_line = re.sub(r"\([^)]*\)", "", clean_line)
+            clean_line = array_dimensions_search.sub("", clean_line).strip()
+            clean_line = array_assignment_search.sub("", clean_line)
             variables = [var.strip() for var in clean_line.split(",")]
             for var in variables:
+                if digit_search.fullmatch(var):
+                    continue  # Skip if it's just a number
                 var = var.split(r"=", 1)[0].strip()  # Remove any assignment part
-                if var.upper() == var:
+                if var and var.upper() == var:
                     failures += 1
                     error_log = add_error_log(
                         error_log,
-                        f"Found UPPERCASE variable name in declaration at line {count}: {var}",
+                        f"Found UPPERCASE variable name in declaration at line {count}:"
+                        + f' "{var}"',
                         count,
                     )
     return TestResult(

--- a/script_umdp3_checker/umdp3_rules_S3.py
+++ b/script_umdp3_checker/umdp3_rules_S3.py
@@ -151,7 +151,7 @@ def r3_1_1_there_can_be_only_one(
                 continue  # Skip empty lines
             unit_name_search = re.search(rf"END\s+{unit_type}\s+(\w+)", executable_line)
             if unit_name_search:
-                if unit_name_search.group(1) == unit_name:
+                if unit_name_search.group(1).upper() == unit_name.upper():
                     return (True, "")
                 else:
                     return (

--- a/script_umdp3_checker/umdp3_rules_S3.py
+++ b/script_umdp3_checker/umdp3_rules_S3.py
@@ -337,7 +337,7 @@ TODO: This is a very simplistic check and will not detect many
     )
     digit_search = re.compile(r"([+-]?\d+\.\d+|[+-]?\d+)")
     array_dimensions_search = re.compile(
-        r"\([^)]*\)"
+        r"\([^()]*\)"
     )  # finds array dimensions in declaration
     array_assignment_search = re.compile(
         r"=\s*\[[^\]]*\]\s*"
@@ -349,7 +349,8 @@ TODO: This is a very simplistic check and will not detect many
         if declaration_search.search(clean_line):
             full_line = concatenate_lines(lines, count)
             clean_line = full_line.split("::", 1)[1].strip()
-            clean_line = array_dimensions_search.sub("", clean_line).strip()
+            while array_dimensions_search.sub("", clean_line).strip() != clean_line:
+                clean_line = array_dimensions_search.sub("", clean_line).strip()
             clean_line = array_assignment_search.sub("", clean_line)
             variables = [var.strip() for var in clean_line.split(",")]
             for var in variables:


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: @Pierre-siddall 
Code Reviewer: @t00sa 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

Now that UMDP3 checker has been unleashed on an unsuspectin user base, some "real world" issues are arrising.
This change is intended to address the first few common ones to be highlighted...

- [x] False fails for uppercase variable names, especially on the assignment of logicals e.g.` l_switch = .FALSE.`
- [x] More False fails in comments at the end of variable declaration lines
- [x] More False fails mistaking cpp directives for Fortran statements e.g. `#endif` triggering "unseparated keywords" test.
- [x] Complaint on #199 that the list of line numbers for error is hard to interpret.
- [x] Variable declaration checking doesn't account for multiple variables on one line
- [x] Variable declaration checking doesn't account for variables on continuation lines
- [x] Order of asserts in pytest tests make identifying the specific failure point in a style check hard to determine.
- [x] Array assignation at declaration (using "`= [1, 2, 3, 4]`") was triggering failures in the uppercase variable checker
- [x] Multiple array dimensions appears to bamboozle the fix for array dimensions ([added a unit test for this](https://github.com/MetOffice/SimSys_Scripts/pull/234/commits/ee607410fb24076c60c5d72997b53aa11566caa7))
- [x] The "one programing unit flags a failure if the case of the unit name differs between declaration and closure. Team vote was that this should be a case insensitive test as Fortran doesn't care.
- [ ] The "deprecated intrinsics" check is spotting a lot of what are actually badly named variables. Particulalry "LONG"

Additional unit tests have been added to ensure the problems identified above don't creep back in.

Prior to this change, the UMDP3 conformance checker identifies 779 files failing in the UM main branch.
After this change, that drops to 282 files. (of which a dozen are possibly false "obsolescent intrinsic" failures)

The issue with variables called LONG (and possibly others) being identified as a deprecated intrinsic, will most likely have to be dealt with by making changes to the UM itself.

- Some of this fixes sub issues on #199 


<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number (auto-closes the issue)
- fixes #issue-number (auto-closes the issue)
- is related to #issue-number
-->

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [x] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [x] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] This change has been tested appropriately (please describe)

## Security Considerations

- [x] I have reviewed my changes for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable

