### PR TITLE
Do not wait for retrigger if suites are complete

### DIFF
--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -178,7 +178,7 @@ if __name__ == "__main__":
 
     # Parse the valid_suites for ones which are cylc8 and have failed tasks
     failed_suites = check_failed_suites(valid_suites, cylc_run)
-    
+
     if not failed_suites:
         print("No failed suites found")
         raise SystemExit(0)

--- a/nightly_testing/retrigger_nightlies.py
+++ b/nightly_testing/retrigger_nightlies.py
@@ -178,6 +178,10 @@ if __name__ == "__main__":
 
     # Parse the valid_suites for ones which are cylc8 and have failed tasks
     failed_suites = check_failed_suites(valid_suites, cylc_run)
+    
+    if not failed_suites:
+        print("No failed suites found")
+        raise SystemExit(0)
 
     print("\nFound the following suites with errors:")
     for suite in failed_suites:


### PR DESCRIPTION
# PR Summary

Sci/Tech Reviewer: <!-- SR id, filled by author when ready for review (e.g. @octocat) -->
Code Reviewer: @james-bruten-mo 

Exit from the retrigger script immediately if no failures are found instead of waiting two minutes.

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] My code follows the project's [style guidelines](https://metoffice.github.io/lfric_core/how_to_contribute/index.html#how-to-contribute-index)
- [ ] Comments have been included that aid understanding and enhance the readability of the code
- [x] My changes generate no new warnings
- [ ] All automated checks in the CI pipeline have completed successfully

## Testing

- [x] This change has been tested appropriately (please describe)

Tested interactively:

```
vdi> python3 nightly_testing/retrigger_nightlies.py
No failed suites found
vdi>
```

## Security Considerations

- [ ] I have reviewed my changes for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## AI Assistance and Attribution

- [ ] ~Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise, Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)~

<!-- If AI has been used, please provide more details here -->

# Sci/Tech Review

<!-- To be completed by the Sci/Tech Reviewer -->
<!-- May be skipped for trivial tickets -->

- [ ] I understand this area of code and the changes being added
- [ ] The proposed changes correspond to the pull request description
- [ ] Documentation is sufficient (do documentation papers need updating)
- [ ] Sufficient testing has been completed

(_Please alert the code reviewer via a tag when you have approved the SR_)

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable

